### PR TITLE
Clean docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ weblate:
 database:
   # You can change used database here:
   image: postgres:9.4
-  volumes:
-    - ./weblate/mysql-charset.conf:/etc/mysql/conf.d/charset.cnf
   env_file:
     - ./weblate/environment
 cache:


### PR DESCRIPTION
The file `/etc/mysql/conf.d/charset.cnf` isn't needed by the PostgreSQL container.