### PR TITLE
upgrade override.yml to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,19 @@ https://docs.weblate.org/en/latest/admin/deployments.html#docker
 1. Create a `docker-compose.override.yml` file with your settings.
 See [weblate/environment]() for a full list of environment vars
 
-		weblate:
-		  ports:
-		    - "80:8000"
-		  environment:
-		    - WEBLATE_EMAIL_HOST=email.com
-		    - WEBLATE_EMAIL_HOST_USER=user
-		    - WEBLATE_EMAIL_HOST_PASSWORD=pass
-		    - WEBLATE_SECRET_KEY=something more secret
-		    - WEBLATE_ALLOWED_HOSTS=your hosts
+```yml
+version: '2'
+services:
+  weblate:
+    ports:
+      - "80:8000"  
+    environment:  
+      - WEBLATE_EMAIL_HOST=email.com
+      - WEBLATE_EMAIL_HOST_USER=user
+      - WEBLATE_EMAIL_HOST_PASSWORD=pass
+      - WEBLATE_SECRET_KEY=something more secret
+      - WEBLATE_ALLOWED_HOSTS=your hosts
+```
 
 2. Build the instances
 


### PR DESCRIPTION
fix `docker-compose.override.yml` error under docker-compose 1.8.0:

```
ERROR: Version mismatch: file ./docker-compose.yml specifies version 2.0 but extension file ./docker-compose.override.yml uses version 1
```