### PR TITLE
fix ADD-ed files permissions

### DIFF
--- a/weblate/Dockerfile
+++ b/weblate/Dockerfile
@@ -17,6 +17,7 @@ RUN bin/pip install -r /tmp/requirements.txt
 RUN rm /tmp/requirements.txt
 
 ADD settings.py /app/etc/
+RUN chmod a+r /app/etc/settings.py
 ADD start /app/bin/
 RUN chmod a+rx /app/bin/start
 

--- a/weblate/Dockerfile
+++ b/weblate/Dockerfile
@@ -18,7 +18,7 @@ RUN rm /tmp/requirements.txt
 
 ADD settings.py /app/etc/
 ADD start /app/bin/
-RUN chmod +x /app/bin/start
+RUN chmod a+rx /app/bin/start
 
 WORKDIR /tmp
 


### PR DESCRIPTION
in certain setups where umask is not `002` resulting image contains script that is not world accessible:

```
# docker-compose run --rm  --entrypoint bash  weblate
weblate@64e68f4a8aa1:/tmp$ ls -l /app/bin/start 
-rwxrwx--x 1 root root 322 Sep  6 06:09 /app/bin/start
```

this results unusable container:

```
# docker-compose run --rm weblate migrate
/bin/sh: 0: Can't open /app/bin/start
```