### PR TITLE
don't ask user for collectstatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [weblate/environment]() for a full list of environment vars
 3. Setup the environment
 
         docker-compose run --rm weblate migrate
-        docker-compose run --rm weblate collectstatic
+        docker-compose run --rm weblate collectstatic --noinput
         docker-compose run --rm weblate createadmin
     
 4. Start up


### PR DESCRIPTION
```
# docker-compose run --rm weblate collectstatic 
Postgres is up

You have requested to collect static files at the destination
location as specified in your settings:

    /app/data/static

This will overwrite existing files!
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: ^C
```

after the change:
```
# docker-compose run --rm weblate collectstatic --noinput
Postgres is up
Copying '/app/local/lib/python2.7/site-packages/django/contrib/admin/static/admin/css/base.css'
Copying '/app/local/lib/python2.7/site-packages/django/contrib/admin/static/admin/css/changelists.css'
Copying '/app/local/lib/python2.7/site-packages/django/contrib/admin/static/admin/css/dashboard.css'
Copying '/app/local/lib/python2.7/site-packages/django/contrib/admin/static/admin/css/fonts.css
...
Copying '/app/local/lib/python2.7/site-packages/weblate/static/js/mousetrap-global-bind.js'
Copying '/app/local/lib/python2.7/site-packages/weblate/static/js/mousetrap.js'

113 static files copied to '/app/data/static'.
```