### PR TITLE
Update Dockerfile

### DIFF
--- a/weblate/Dockerfile
+++ b/weblate/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Michal Čihař <michal@cihar.com>
 # Add user early to get a consistent userid
 RUN useradd --shell /bin/sh --user-group weblate
 
+RUN install -d -o weblate -g weblate -m 755 /app/data
+
 ADD requirements.txt /tmp/requirements.txt
 
 # Install dependencies
@@ -16,6 +18,9 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
   && apt-get -y purge python-pip \
   && apt-get clean
 
+# Examples
+RUN curl https://dl.cihar.com/weblate/Weblate-2.8.tar.gz | tar xzf - --strip-components=1 --no-same-owner -C /app Weblate-2.8/examples
+
 # Settings
 ADD settings.py /app/etc/
 RUN chmod a+r /app/etc/settings.py
@@ -24,10 +29,6 @@ RUN chmod a+r /app/etc/settings.py
 ADD start /app/bin/
 RUN chmod a+rx /app/bin/start
 
-# Examples
-RUN curl https://dl.cihar.com/weblate/Weblate-2.8.tar.gz | tar xzf - --strip-components=1 -C /app Weblate-2.8/examples
-
-RUN install -d -o weblate -g weblate -m 755 /app/data
 RUN ln -s /app/etc/settings.py /usr/local/lib/python2.7/dist-packages/weblate/settings.py
 ENV DJANGO_SETTINGS_MODULE weblate.settings
 ENV START_CMD "/usr/local/bin/django-admin"


### PR DESCRIPTION
extract examples as root; also reorder for better docker build cache


```
bash-4.3# ls -l
total 4
drwxr-xr-x 2 root root    18 Oct 19 15:15 bin
drwxr-xr-x 8 http http    95 Oct 19 13:20 data
drwxr-xr-x 2 root root    24 Oct 19 15:18 etc
drwxr-xr-x 2 1000 users 4096 Aug 31 08:49 examples
bash-4.3# rm -rf examples/
bash-4.3# curl https://dl.cihar.com/weblate/Weblate-2.8.tar.gz | tar xzf - --strip-components=1 --no-same-owner -C /app Weblate-2.8/examples
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8800k  100 8800k    0     0  7257k      0  0:00:01  0:00:01 --:--:-- 7260k
bash-4.3# ls -l
total 4
drwxr-xr-x 2 root root   18 Oct 19 15:15 bin
drwxr-xr-x 8 http http   95 Oct 19 13:20 data
drwxr-xr-x 2 root root   24 Oct 19 15:18 etc
drwxr-xr-x 2 root root 4096 Aug 31 08:49 examples
bash-4.3#
```

and extract examples before adding entrypoint. likely to modify entrypoint more often than need to refetch examples.

the `same-owner` arg can be dropped if the next release tarball is created with `--owner=root` & `--group=root`