### PR TITLE
use django own method to generate secret

### DIFF
--- a/weblate/start
+++ b/weblate/start
@@ -15,7 +15,8 @@ unset PGPASSWD
 
 # Generate secret
 if [ ! -f /app/data/secret ] ; then
-    tr -dc 'a-zA-Z0-9~!@#$%^&*_()+}{?></";.,[]=-' < /dev/urandom | fold -w 50 | head -n 1 > /app/data/secret
+    # https://github.com/django/django/blob/1.10.2/django/utils/crypto.py#L54-L56
+    python -c "from django.utils.crypto import get_random_string; print get_random_string(50)" > /app/data/secret
 fi
 
 # Migrate database to current version and collect static files


### PR DESCRIPTION
following discussion on 7f1b6b56a

thought why not just use Django itself, it's already installed!


example:
```
$ python -c "from django.utils.crypto import get_random_string; print get_random_string(50)"
KMiFcPMlVuBkwT0Z6MLqZB4jzAdrOQ5T2Q05n1ZNBUW5rGO4t1
```