### PR TITLE
Add python-yaml package definition to Weblate Dockerfile

### DIFF
--- a/weblate/Dockerfile
+++ b/weblate/Dockerfile
@@ -10,7 +10,7 @@ ADD requirements.txt /tmp/requirements.txt
 
 # Install dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
-  && apt-get install --no-install-recommends -y ssh curl python-pip python-lxml python-pillow python-psycopg2 python-memcache python-dateutil python-rcssmin python-rjsmin gettext postgresql-client \
+  && apt-get install --no-install-recommends -y ssh curl python-pip python-lxml python-yaml python-pillow python-psycopg2 python-memcache python-dateutil python-rcssmin python-rjsmin gettext postgresql-client \
   && apt-get install --no-install-recommends -y -t jessie-backports mercurial git git-svn subversion \
   && apt-get -y upgrade \
   && pip install -r /tmp/requirements.txt \


### PR DESCRIPTION
In order to enable YAML files in Weblate Docker container, the 'python-yaml' should be installed. Therefore I recommend to include this package into the Weblate Dockerfile.