### PR TITLE
Add home directory for weblate user

### DIFF
--- a/weblate/Dockerfile
+++ b/weblate/Dockerfile
@@ -2,7 +2,11 @@ FROM debian:jessie-backports
 MAINTAINER Michal Čihař <michal@cihar.com>
 
 # Add user early to get a consistent userid
-RUN useradd --shell /bin/sh --user-group weblate
+RUN useradd --shell /bin/sh --user-group weblate \
+  && mkdir -p /home/weblate/.ssh \
+  && touch /home/weblate/.ssh/authorized_keys \
+  && chown -R weblate:weblate /home/weblate \
+  && chmod 700 /home/weblate/.ssh
 
 RUN install -d -o weblate -g weblate -m 755 /app/data
 


### PR DESCRIPTION
Official documentation (1) told us about SSH access.
This change allow us add ~/.ssh/id_rsa key easiest

(1) https://docs.weblate.org/en/weblate-2.9/faq.html#git-export