### PR TITLE
Allow PostgreSQL host and port to be defined as environment variables

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -50,9 +50,9 @@ DATABASES = {
         # Database password, not used with sqlite3.
         'PASSWORD': os.environ['POSTGRES_PASSWORD'],
         # Set to empty string for localhost. Not used with sqlite3.
-        'HOST': 'database',
+        'HOST': os.environ['POSTGRES_HOST'],
         # Set to empty string for default. Not used with sqlite3.
-        'PORT': '',
+        'PORT': os.environ['POSTGRES_PORT'],
     }
 }
 

--- a/start
+++ b/start
@@ -4,7 +4,7 @@ set -e
 export PGPASSWORD="$POSTGRES_PASSWORD"
 
 # Wait for database to get available
-until psql -h "database" -U "$POSTGRES_USER" -c 'SELECT 1' > /dev/null 2>&1 ; do
+until psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -c 'SELECT 1' > /dev/null 2>&1 ; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
Hello, we have been deploying Weblate in our cluster and have noticed the inconvenience to be able to configure the database host. We already had a PostgreSQL instance and did not wish to use the specific one configured in the docker-compose file. Additionally, we are deploying with Kubernetes and Cloud SQL Proxy, so this was a nuisance.

With this PR users should be able to configure the host/port of their PostgreSQL instance.

Notice that if **POSTGRES_PORT** is not set, the script check will still work.

I don't understand the nature of the two branches, but since there's a dependency between them I created two related PRs.

Furthermore, I wanted to suggest to increase the sleep time of the database status check via psql, currently 1s is log cluttering.