### PR TITLE
Added POSTGRES_HOST and POSTGRES_PORT to the environment list file

### DIFF
--- a/environment
+++ b/environment
@@ -34,6 +34,8 @@ WEBLATE_REGISTRATION_OPEN=1
 POSTGRES_PASSWORD=weblate
 POSTGRES_USER=weblate
 POSTGRES_DATABASE=weblate
+POSTGRES_HOST=database
+#POSTGRES_PORT=
 
 # Mail server, the server has to listen on port 587 and understand TLS
 WEBLATE_EMAIL_HOST=smtp.gmail.com


### PR DESCRIPTION
DEPENDS ON: https://github.com/WeblateOrg/docker/pull/41

----
Hello, we have been deploying Weblate in our cluster and have noticed the inconvenience to be able to configure the database host. We already had a PostgreSQL instance and did not wish to use the specific one configured in the docker-compose file. Additionally, we are deploying with Kubernetes and Cloud SQL Proxy, so this was a nuisance.

With this PR users should be able to configure the host/port of their PostgreSQL instance.

Notice that if **POSTGRES_PORT** is not set, the script check will still work.

I don't understand the nature of the two branches, but since there's a dependency between them I created two related PRs.

Furthermore, I wanted to suggest to increase the sleep time of the database status check via psql, currently 1s is log cluttering.