### PR TITLE
Set REDIRECT_IS_HTTPS to match ENABLE_HTTPS value

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -539,6 +539,7 @@ SITE_TITLE = os.environ.get('WEBLATE_SITE_TITLE', 'Weblate')
 
 # Whether site uses https
 ENABLE_HTTPS = os.environ.get('WEBLATE_ENABLE_HTTPS', '0') == '1'
+REDIRECT_IS_HTTPS = ENABLE_HTTPS
 
 # Make CSRF cookie HttpOnly, see documentation for more details:
 # https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-httponly

--- a/settings.py
+++ b/settings.py
@@ -539,7 +539,11 @@ SITE_TITLE = os.environ.get('WEBLATE_SITE_TITLE', 'Weblate')
 
 # Whether site uses https
 ENABLE_HTTPS = os.environ.get('WEBLATE_ENABLE_HTTPS', '0') == '1'
-REDIRECT_IS_HTTPS = ENABLE_HTTPS
+
+# Use HTTPS when creating redirect URLs for social authentication, see
+# documentation for more details:
+# http://python-social-auth-docs.readthedocs.io/en/latest/configuration/settings.html#processing-redirects-and-urlopen
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = ENABLE_HTTPS
 
 # Make CSRF cookie HttpOnly, see documentation for more details:
 # https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-httponly


### PR DESCRIPTION
By default return URLs created by python-social-auth uses **http** links. It can be forced to use **https** URLs by setting `REDIRECT_IS_HTTPS` to `true`. This PR changes _settings.py_ in docker image to use `WEBLATE_ENABLE_HTTPS` environment variable for setting `REDIRECT_IS_HTTPS` value.

I have stumbled on this by trying to create **https** only weblate instance with Google authentication backend enabled. On the Google auth configuration I have white-listed only **https** address of the weblate instance and whole authentication workflow was failing until `REDIRECT_IS_HTTPS` was set to `true`.

More details in [python-social-auth-docs](http://python-social-auth-docs.readthedocs.io/en/latest/configuration/settings.html?highlight=REDIRECT_IS_HTTPS) section "Processing redirects and urlopen". I have not tested this with other social auth backends but I suppose they might have the same issue.

If you approve of this change we could add this to the _settings_example.py_ in the main repo or mention about such behaviour it in the docs.