### PR TITLE
Lighter alternatives to dependency images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,14 @@ services:
       - database
       - cache
   database:
-    image: postgres:9.6
+    image: postgres:9.6-alpine
     env_file:
       - ./environment
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: always
   cache:
-    image: memcached:1.4
+    image: memcached:1.5-alpine
     restart: always
 volumes:
   weblate-data: {}


### PR DESCRIPTION
Additionally, memcached:1.4 doesn't seem to be supported anymore: https://hub.docker.com/_/memcached/