### PR TITLE
minor docker-compose-https.yml example update for https-portal

### DIFF
--- a/docker-compose-https.yml
+++ b/docker-compose-https.yml
@@ -33,6 +33,8 @@ services:
     links:
       - weblate
     restart: always
+    environment:
+      STAGE: production
 volumes:
   weblate-data: {}
   postgres-data: {}


### PR DESCRIPTION
STAGE is staging by default, which results in a test (untrusted) certificate from Let's Encrypt.