### PR TITLE
Add database flag to psql command

### DIFF
--- a/start
+++ b/start
@@ -17,7 +17,7 @@ if [ -z "$POSTGRES_PORT" ] ; then
 fi
 
 # Wait for database to get available
-until psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -c 'SELECT 1' > /dev/null 2>&1 ; do
+until psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -d "$POSTGRES_DATABASE" -U "$POSTGRES_USER" -c 'SELECT 1' > /dev/null 2>&1 ; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
This ensures that the command works if the default database named the
same as the user doesn't exist. It also makes more sense to check
connection to the database which we intend to use.