### PR TITLE
echo POSTGRES_PASSWORD into PGPASSWORD

### DIFF
--- a/start
+++ b/start
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-export PGPASSWORD="$POSTGRES_PASSWORD"
+export PGPASSWORD=$(echo $POSTGRES_PASSWORD)
 
 export WEBLATE_CMD="/usr/local/bin/weblate"
 


### PR DESCRIPTION
I am trying to run this container on kubernetes but for some reason PGPASSWORD is not set correctly by `export PGPASSWORD="$POSTGRES_PASSWORD"`. That means that the container is stuck in trying to check the connection. If I echo the variable when setting `PGPASSWORD`, it just works. The following is an example where I ran the `psql` command directly.

```
root@translations-1509997817-b3k58:/# PGPASSWORD=$POSTGRES_PASSWORD psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -d "$POSTGRES_DATABASE" -U "$POSTGRES_USER" -c 'SEL>
psql: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
FATAL:  password authentication failed for user "spiiradmin"
root@translations-1509997817-b3k58:/# PGPASSWORD=$(echo $POSTGRES_PASSWORD) psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -d "$POSTGRES_DATABASE" -U "$POSTGRES_USER">
 ?column?
----------
        1
(1 row)

```

It might be related to special characters in the password or something like that. I have been unable to pinpoint the exact problem. Nevertheless this fixes the issue.