### PR TITLE
Make memcached host and port configurable through environment vars

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -696,8 +696,8 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': '{0}:{1}'.format(
-            'cache',
-            '11211',
+            os.environ.get('MEMCACHED_HOST'),
+            os.environ.get('MEMCACHED_PORT'),
         )
     },
     'avatar': {


### PR DESCRIPTION
This PR makes `settings.py` configure memcached based on the values of the environment variables `MEMCACHED_HOST` and `MEMCACHED_PORT`. This pull request depends on PR #61.