### PR TITLE
add WEBLATE_EMAIL_USE_SSL to match EMAIL_USE_SSL

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -772,6 +772,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Email server
 EMAIL_USE_TLS = os.environ.get('WEBLATE_EMAIL_USE_TLS', '1') == '1'
+EMAIL_USE_SSL = os.environ.get('WEBLATE_EMAIL_USE_SSL', '0') == '1'
 EMAIL_HOST = os.environ.get('WEBLATE_EMAIL_HOST', '')
 EMAIL_HOST_USER = os.environ.get(
     'WEBLATE_EMAIL_HOST_USER',


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.11/ref/settings/#email-use-ssl