### PR TITLE
Enable Glosbe and MyMemory machine translations via enviroment variables

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -568,6 +568,12 @@ MT_MYMEMORY_EMAIL = None
 MT_MYMEMORY_USER = None
 MT_MYMEMORY_KEY = None
 
+if 'WEBLATE_MT_MYMEMORY_ENABLED' in os.environ:
+    MACHINE_TRANSLATION_SERVICES += ('weblate.trans.machine.mymemory.MyMemoryTranslation',)
+
+if 'WEBLATE_MT_GLOSBE_ENABLED' in os.environ:
+    MACHINE_TRANSLATION_SERVICES += ('weblateweblate.trans.machine.glosbe.GlosbeTranslation',)   
+    
 # Google API key for Google Translate API
 MT_GOOGLE_KEY = os.environ.get('WEBLATE_MT_GOOGLE_KEY', None)
 


### PR DESCRIPTION
Machine translations currently cannot be configured completely via Docker enviroment variables.
This PR adds `WEBLATE_MT_MYMEMORY_ENABLED` and `WEBLATE_MT_GLOSBE_ENABLED` in order to enable these services.