### PR TITLE
enable uwsgi harakiri mode and stats server

### DIFF
--- a/weblate.uwsgi.ini
+++ b/weblate.uwsgi.ini
@@ -20,3 +20,10 @@ umask = 0022
 uid = weblate
 gid = weblate
 chmod-socket = 666
+
+# enable harakiri mode
+harakiri = 30
+harakiri-verbose = true
+# enable uWSGI stats server
+stats = :1717
+stats-http = true


### PR DESCRIPTION
fix `Resource temporarily unavailable` error

nginx error log:

```
[error] 19#19: *259 connect() to unix:/var/run/uwsgi/app/weblate/socket failed (11: Resource temporarily unavailable) while connecting to upstream, client: 10.0.1.181, server: ....
```
