### PR TITLE
Prefix memcached keys, so we do not have to worry about two django ap…

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -761,7 +761,8 @@ if 'MEMCACHED_HOST' in os.environ:
         'LOCATION': '{0}:{1}'.format(
             os.environ.get('MEMCACHED_HOST', 'cache'),
             os.environ.get('MEMCACHED_PORT', '11211'),
-        )
+        ),
+        'KEY_PREFIX': 'weblate',
     }
 else:
     CACHES['default'] = {


### PR DESCRIPTION
…ps using same cache

We use memcached in AWS for multiple services, with prefixing keys different django apps wont clash.