### PR TITLE
Add ability to use other db engines

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -58,7 +58,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         # Use 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.postgresql_psycopg2'),
         # Database name or path to database file if using sqlite3.
         'NAME': os.environ['POSTGRES_DATABASE'],
         # Use same database for tests (needed as Docker MySQL can


### PR DESCRIPTION
Ideally the whole section should be changed from e.g. POSTGRES_PASSWORD to DB_PASSWORD etc but in order to not break other peoples setup I only added the engine part which is all I need to use it with MySQL