### PR TITLE
Fix applying multiple patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN chmod a+r /etc/weblate/settings.py && \
 
 # Apply hotfixes
 RUN find /usr/src/weblate -name '*.patch' -print0 | \
-    xargs -0 -r patch -p1 -d /usr/local/lib/python3.6/dist-packages/ -i
+    xargs -n1 -0 -r patch -p1 -d /usr/local/lib/python3.6/dist-packages/ -i
 
 # Entrypoint
 COPY start /app/bin/


### PR DESCRIPTION
When applying multiple patches the Dockerfile ends with an error (because all found patch files will be passed to patch)

`-n1 tells xargs to run the given command once per argument.`

-n1 is needed to pass every found file solely to patch