### PR TITLE
Use eventlet for celery workers

### DIFF
--- a/etc/supervisor/conf.d/weblate.conf
+++ b/etc/supervisor/conf.d/weblate.conf
@@ -23,7 +23,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-search]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=search --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 -P eventlet --queues=search --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=memory --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 -P eventlet --queues=memory --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/etc/supervisor/conf.d/weblate.conf
+++ b/etc/supervisor/conf.d/weblate.conf
@@ -15,7 +15,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'celery@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'celery@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1000 -P eventlet --queues=celery --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/etc/supervisor/conf.d/weblate.conf
+++ b/etc/supervisor/conf.d/weblate.conf
@@ -15,7 +15,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'celery@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1000 -P eventlet --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'celery@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 -P eventlet --queues=celery --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -23,7 +23,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-search]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 -P eventlet --queues=search --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 -P eventlet --queues=search --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 -P eventlet --queues=memory --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 -P eventlet --queues=memory --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-redis==4.10.0
 phply==1.2.5
 django-auth-ldap==1.7.0
 rollbar
+eventlet
 raven
 setuptools
 jellyfish==0.7.1


### PR DESCRIPTION
Use eventlet instead of fork for celery workers.

This allows for 1000 concurrent tasks instead of just 4, and saves 400 MB of ram.