### PR TITLE
Scale uwsgi workers on demand

### DIFF
--- a/etc/uwsgi/apps-enabled/weblate.ini
+++ b/etc/uwsgi/apps-enabled/weblate.ini
@@ -8,8 +8,12 @@ python-path   = /usr/local/lib/python3.6/dist-packages
 # virtualenv = /path/to/weblate/virtualenv
 # Needed for OAuth/OpenID
 buffer-size   = 8192
-# Increase number of workers for heavily loaded sites
+# maximum number of workers that can be spawned
 workers       = 6
+# minimum number of workers to keep at all times
+cheaper = 2
+# number of workers to spawn at startup
+cheaper-initial = 2
 # Needed for background processing
 enable-threads = true
 # Child processes do not need file descriptors


### PR DESCRIPTION
Rather than start 6 workers at start,  start 2,  and scale up as needed. 
This saves some memory on low traffic weblate installs