### PR TITLE
Make /healthz/ endopint exempt from SSL redirect

### DIFF
--- a/etc/weblate/settings.py
+++ b/etc/weblate/settings.py
@@ -697,6 +697,10 @@ CSRF_USE_SESSIONS = True
 SESSION_COOKIE_SECURE = ENABLE_HTTPS
 # SSL redirect
 SECURE_SSL_REDIRECT = ENABLE_HTTPS
+# SSL redirect URL exemption list
+SECURE_REDIRECT_EXEMPT = (
+   r'/healthz/$',           # Allowing HTTP access to health check
+)
 # Session cookie age (in seconds)
 SESSION_COOKIE_AGE = 1209600
 


### PR DESCRIPTION
If weblate is running behind a proxy and is configured to redirect to HTTPS, `/healthz/` endpoint also becomes unavailable via good old HTTP for no good reason. This trips up some health check probes making them believe that the service is not available even when it in fact is. It is possible to work around this inconvenience by injecting `X-Forwarded-Proto: https` header but in some scenarios, even that is not feasible. Therefore I propose to just make `/healthz/` endpoint exempt from the SSL redirect. Optionally, we could parameterize it, too. 

More context: https://twitter.com/mareksuscak/status/1139661979516170240