### PR TITLE
Fix secure redirect URL pattern

### DIFF
--- a/etc/weblate/settings.py
+++ b/etc/weblate/settings.py
@@ -699,7 +699,7 @@ SESSION_COOKIE_SECURE = ENABLE_HTTPS
 SECURE_SSL_REDIRECT = ENABLE_HTTPS
 # SSL redirect URL exemption list
 SECURE_REDIRECT_EXEMPT = (
-   r'/healthz/$',           # Allowing HTTP access to health check
+    r'healthz/$',           # Allowing HTTP access to health check
 )
 # Session cookie age (in seconds)
 SESSION_COOKIE_AGE = 1209600


### PR DESCRIPTION
Django [strips it away](https://github.com/django/django/blob/817c6cdf0e2a72362045ca503af01830df9b9d36/django/middleware/security.py#L21) for no obvious reason so the previous code wasn't working as expected.

UPDATE: 
We've just tested this patch and can confirm it works as expected in the Kubernetes environment.