### PR TITLE
Add an env var for the web server port

### DIFF
--- a/etc/nginx/default.tpl
+++ b/etc/nginx/default.tpl
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen ${WEBLATE_PORT} default_server;
     root /app/data/static;
 
     location ~ ^/favicon.ico$ {
@@ -14,13 +14,13 @@ server {
         expires 30d;
     }
 
-    location {{URL_PREFIX}}/static/ {
+    location ${WEBLATE_URL_PREFIX}/static/ {
         # DATA_DIR/static/
         alias /app/data/static/;
         expires 30d;
     }
 
-    location {{URL_PREFIX}}/media/ {
+    location ${WEBLATE_URL_PREFIX}/media/ {
         # DATA_DIR/media/
         alias /app/data/media/;
         expires 30d;

--- a/etc/nginx/run.sh
+++ b/etc/nginx/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sed -e "s%{{URL_PREFIX}}%${WEBLATE_URL_PREFIX}%g" /etc/nginx/default.tpl > /etc/nginx/sites-available/default
+envsubst < /etc/nginx/default.tpl > /etc/nginx/sites-available/default;
 exec /usr/sbin/nginx -g "daemon off;"

--- a/start
+++ b/start
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Export Weblate variables
+export WEBLATE_CMD="/usr/local/bin/weblate"
+if [ -z "$WEBLATE_PORT" ] ; then
+    export WEBLATE_PORT=80
+fi
+
 # Provide sane default value
 if [ -z "$POSTGRES_SSL_MODE" ] ; then
     export POSTGRES_SSL_MODE="prefer"
@@ -14,8 +20,6 @@ export PGSSLMODE="$POSTGRES_SSL_MODE"
 if [ -n "$REDIS_PASSWORD" ] ; then
     export REDISCLI_AUTH="$REDIS_PASSWORD"
 fi
-
-export WEBLATE_CMD="/usr/local/bin/weblate"
 
 # Update the time zone
 zonefile="/usr/share/zoneinfo/$WEBLATE_TIME_ZONE"


### PR DESCRIPTION
There are some infrastructure when the security policies in docker doesn't allow a process to expose the 80 port. In order to adapt those, I added an environment variable in order to allow the user to change the webserver port.