### PR TITLE
refactor(root): image can run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN set -x \
     cython \
     gcc \
     g++ \
-    tesseract-ocr \ 
+    tesseract-ocr \
     patch \
   && pip3 install Weblate==$VERSION -r /usr/src/weblate/requirements.txt \
   && python3 -c 'from phply.phpparse import make_parser; make_parser()' \
@@ -93,6 +93,9 @@ RUN curl -L https://github.com/github/hub/releases/download/v2.2.9/hub-linux-amd
 
 # Configuration for Weblate, nginx, uwsgi and supervisor
 COPY etc /etc/
+
+RUN chown -R weblate:weblate /etc/nginx/sites-available/ /etc/profile.d/ /var/log/nginx/ /var/lib/nginx /app/data /run
+
 RUN chmod a+r /etc/weblate/settings.py && \
   ln -s /etc/weblate/settings.py /usr/local/lib/python3.7/dist-packages/weblate/settings.py
 
@@ -105,5 +108,6 @@ COPY start /app/bin/
 RUN chmod a+rx /app/bin/start
 
 EXPOSE 80
+USER weblate
 ENTRYPOINT ["/app/bin/start"]
 CMD ["runserver"]

--- a/etc/supervisor/conf.d/weblate.conf
+++ b/etc/supervisor/conf.d/weblate.conf
@@ -15,7 +15,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate --loglevel info --concurrency=4 --queues=celery --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -23,7 +23,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=2 --queues=notify --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate --loglevel info --concurrency=2 --queues=notify --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-search]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=search --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --concurrency=1 --queues=search --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -39,7 +39,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=memory --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -47,7 +47,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-beat]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery beat --app weblate --loglevel info --uid weblate --gid weblate --pidfile /run/celery/beat.pid
+command = /usr/local/bin/celery beat --app weblate --loglevel info --pidfile /run/celery/beat.pid
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/etc/uwsgi/apps-enabled/weblate.ini
+++ b/etc/uwsgi/apps-enabled/weblate.ini
@@ -24,6 +24,7 @@ umask = 0022
 uid = weblate
 gid = weblate
 chmod-socket = 666
+chown-socket = weblate:weblate
 
 # enable harakiri mode
 harakiri = 3600

--- a/start
+++ b/start
@@ -26,10 +26,8 @@ if [ -n "$WEBLATE_TIME_ZONE" -a -f "$zonefile" ] ; then
     mv -f /etc/localtime.dpkg-new /etc/localtime
 fi
 
-chown -R weblate:weblate /app/data
-
 run_weblate() {
-    sudo -u weblate -E $WEBLATE_CMD "$@"
+    $WEBLATE_CMD "$@"
 }
 
 fail_dep() {
@@ -85,7 +83,6 @@ if [ ! -f /app/data/secret ] ; then
     # https://github.com/django/django/blob/1.10.2/django/utils/crypto.py#L54-L56
     python3 -c "from django.utils.crypto import get_random_string; print(get_random_string(50))" > /app/data/secret
 fi
-chown weblate:weblate /app/data/secret
 
 export | grep -E 'WEBLATE_|POSTGRES_|DJANGO_|REDIS_' > /etc/profile.d/weblate.sh
 
@@ -120,10 +117,10 @@ if [ "x$1" = "xrunserver" ] ; then
 
     # uswgi dir
     mkdir -p /run/uwsgi/app/weblate
-    chown weblate:weblate /run/uwsgi/app/weblate
+
     # Celery pid, remove possible stale PID file
     mkdir -p /run/celery
-    chown weblate:weblate /run/celery
+
     rm -f /run/celery/beat.pid
 
     ln -sf ${NGINX_ACCESS_LOG:-/dev/stdout} /var/log/nginx/access.log
@@ -134,7 +131,7 @@ if [ "x$1" = "xrunserver" ] ; then
         --loglevel=${SUPERVISOR_LOGLEVEL:-info} \
         --logfile_maxbytes=0 \
         --logfile=${SUPERVISOR_LOGFILE:-/dev/null} \
-        --user=root \
+        --user=weblate \
         --configuration=/etc/supervisor/supervisord.conf
 fi
 


### PR DESCRIPTION
I want to run this docker image on openshift, and our security policies don't allow us to run this image as a root user, which is dangerous, see [this article](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b) for reference.

Therefore, I made thoses changes in order to make this image runable as the `weblate` user, which is way cleaner.
