### PR TITLE
save memory by using eventlet for celery workers

### DIFF
--- a/etc/supervisor/conf.d/weblate.conf
+++ b/etc/supervisor/conf.d/weblate.conf
@@ -15,7 +15,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=4 --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate --loglevel info --uid weblate --gid weblate -P eventlet --concurrency=4 --queues=celery --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -23,7 +23,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=2 --queues=notify --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate --loglevel info --uid weblate --gid weblate -P eventlet --concurrency=2 --queues=notify --prefetch-multiplier=4
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-search]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=search --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate --loglevel info --uid weblate --gid weblate -P eventlet --concurrency=1 --queues=search --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -39,7 +39,7 @@ stderr_logfile_maxbytes=0
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate --concurrency=1 --queues=memory --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate --loglevel info --uid weblate --gid weblate -P eventlet --concurrency=1 --queues=memory --prefetch-multiplier=2000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ selenium
 openpyxl==2.6.2
 celery==4.3.0
 celery-batches==0.2
+eventlet
 zeep==3.4.0
 boto3==1.9.188
 httpretty==0.9.6


### PR DESCRIPTION
Before:
```
Tasks:  19 total,   1 running,  18 sleeping,   0 stopped,   0 zombie
%Cpu(s):  0.0 us,  0.0 sy,  0.0 ni,100.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :   1694.6 total,    119.3 free,   1245.4 used,    330.0 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.    295.2 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
      1 root      20   0   26988  18684   5328 S   0.0   1.1   0:00.29 supervisord
    119 weblate   20   0  222736 123188  21280 S   0.0   7.1   0:03.06 celery
    120 weblate   20   0  221876 122176  20376 S   0.0   7.0   0:02.92 celery
    122 weblate   20   0  222216 121724  22048 S   0.0   7.0   0:02.48 celery
    123 weblate   20   0  222480 123296  21408 S   0.0   7.1   0:02.91 celery
    124 weblate   20   0  222740 123488  21576 S   0.0   7.1   0:03.32 celery
    125 weblate   20   0  180040  86064  16256 S   0.0   5.0   0:02.13 uwsgi
    192 weblate   20   0  180040  72304   2496 S   0.0   4.2   0:00.00 uwsgi
    193 weblate   20   0  180040  72304   2496 S   0.0   4.2   0:00.00 uwsgi
    194 weblate   20   0  221968 105104   3728 S   0.0   6.1   0:00.00 celery
    195 weblate   20   0  221972 105244   3864 S   0.0   6.1   0:00.00 celery
    196 weblate   20   0  221108 104920   3640 S   0.0   6.0   0:00.00 celery
    197 weblate   20   0  221968 105088   3712 S   0.0   6.1   0:00.00 celery
    198 weblate   20   0  221968 104980   3600 S   0.0   6.0   0:00.00 celery
    199 weblate   20   0  221972 105308   3928 S   0.0   6.1   0:00.00 celery
    200 weblate   20   0  221972 105308   3928 S   0.0   6.1   0:00.00 celery
    201 weblate   20   0  221972 105316   3932 S   0.0   6.1   0:00.00 celery
    202 root      20   0    5752   3580   3068 S   0.0   0.2   0:00.02 bash
    293 root      20   0    9752   3500   3016 R   0.0   0.2   0:00.00 top
```

after:

```
Tasks:  11 total,   1 running,  10 sleeping,   0 stopped,   0 zombie
%Cpu(s):  0.0 us,  6.7 sy,  0.0 ni, 93.3 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :   1694.6 total,    240.8 free,   1052.5 used,    401.3 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.    483.3 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
      1 root      20   0   27524  19528   5716 S   0.0   1.1   0:00.38 supervisord
    122 weblate   20   0  222216 120476  20800 S   0.0   6.9   0:02.48 celery
    125 weblate   20   0  180040  84736  14928 S   0.0   4.9   0:02.14 uwsgi
    192 weblate   20   0  180040  72000   2192 S   0.0   4.1   0:00.00 uwsgi
    193 weblate   20   0  180040  72000   2192 S   0.0   4.1   0:00.00 uwsgi
    202 root      20   0    5752   3596   3068 S   0.0   0.2   0:00.05 bash
    309 weblate   20   0  228256 136832  31472 S   0.0   7.9   0:02.78 celery
    312 weblate   20   0  228256 136756  31388 S   0.0   7.9   0:02.60 celery
    317 weblate   20   0  228260 136796  31420 S   0.0   7.9   0:02.60 celery
    339 weblate   20   0  228256 136772  31376 S   0.0   7.9   0:02.38 celery
    353 root      20   0    9752   3504   3024 R   0.0   0.2   0:00.00 top
```

This is the updated version of #133 