### PR TITLE
Add openid connect providers to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Whoosh==2.7.4
 translate-toolkit==2.4.0
 translation-finder==1.6
 social-auth-core==3.2.0
+social-auth-core[openidconnect]==3.2.0
 social-auth-app-django==3.1.0
 django-crispy-forms==1.7.2
 django_compressor==2.3


### PR DESCRIPTION
I needed to add this to docker image, otherwise auth porviders using OpenID does not work. Explicitly I was testing with Auth0.com provider.

We've added this by hand to openshift deployment, but it makes sense to have it in docker also.