### PR TITLE
Enable openidconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -x \
     g++ \
     tesseract-ocr \
     patch \
-  && pip3 install Weblate==$VERSION -r /usr/src/weblate/requirements.txt \
+  && pip install Weblate==$VERSION -r /usr/src/weblate/requirements.txt \
   && pip install supervisor-stdout \
   && python3 -c 'from phply.phpparse import make_parser; make_parser()' \
   && ln -s /usr/local/share/weblate/examples/ /app/ \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ siphashc==1.2
 Whoosh==2.7.4
 translate-toolkit==2.4.0
 translation-finder==1.6
-social-auth-core==3.2.0
 social-auth-core[openidconnect]==3.2.0
 social-auth-app-django==3.1.0
 django-crispy-forms==1.7.2


### PR DESCRIPTION
@nijel I think this will fix issue (https://github.com/WeblateOrg/docker/pull/361) with not actually installing `social-auth-core[openidconnect]==3.2.0`.

When I try to use it, it will raise an exception `ModuleNotFoundError: No module named 'jose'`, since this module is required by this openidconnect requirement.


Or am I doing sth wrong from the first place?