### PR TITLE
Add vim in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN set -x \
     supervisor \
     openssh-client \
     curl \
+    vim \
     gir1.2-pango-1.0 \
     python-pip \
     python-setuptools \


### PR DESCRIPTION
Hey there,

It's really hard to fix merge conflicts on weblate without a text editor installed in the image, especially in a k8s cluster when you don't have access to the file on SSH. You are obliged to rsync the conflicting files to your machine, edit them, send rsync them back, it's heavy and your can't `git diff` during edition. I'm proposing via this pull request to add `vim` in the docker image so we can edit files in place (mostly for conflict resolutions).