### PR TITLE
add lab binary and configuration by ENV variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,11 @@ RUN curl -L https://github.com/github/hub/releases/download/v2.2.9/hub-linux-amd
   cp hub-linux-amd64-2.2.9/bin/hub /usr/bin && \
   rm -rf hub-linux-amd64-2.2.9
 
+# Install Lab
+RUN curl -sL "https://github.com/zaquestion/lab/releases/download/v0.17.2/lab_0.17.2_linux_amd64.tar.gz" | tar -C /tmp/ -xzf - \ 
+  && mv /tmp/lab /usr/bin \ 
+  && chmod u+x /usr/bin/lab
+
 # Configuration for Weblate, nginx, uwsgi and supervisor
 COPY etc /etc/
 

--- a/start
+++ b/start
@@ -58,6 +58,19 @@ fail_dep() {
     exit 1
 }
 
+
+if [ ! -z ${WEBLATE_GITLAB_USERNAME+x} ]; then
+    if [ -z ${WEBLATE_GITLAB_HOST+x} ] || [ -z ${WEBLATE_GITLAB_TOKEN+x} ] ; then 
+        echo "WARNING: WEBLATE_GITLAB_HOST or WEBLATE_GITLAB_TOKEN not set. Skip lab.hcl generation..."
+    else 
+        mkdir -p /app/data/home/.config/
+        echo "\"core\" = { \n \"host\" = \"${WEBLATE_GITLAB_HOST}\" \n \"token\" = \"${WEBLATE_GITLAB_TOKEN}\" \n }" > /app/data/home/.config/lab.hcl
+        unset WEBLATE_GITLAB_TOKEN
+        echo "lab configured"
+    fi;
+fi;
+
+
 if [ -n "$MEMCACHED_HOST" ] ; then
     >&2 echo "memcached is no longer supported, please configure redis"
 fi


### PR DESCRIPTION
this fixes #467 
required for WeblateOrg/weblate#3318

To enable automated configuration of lab we introduce 2 new ENV variables
* **WEBLATE_GITLAB_HOST** 
default not set 
eg. https://gitlab.example.com
* **WEBLATE_GITLAB_TOKEN** 
default not set
should be a token you generated for your gitlab translation user

A PR for WeblateOrg/docker-compose and the Weblate docs will be created soon.

