### PR TITLE
Use eventlet instead of multiprocess 

### DIFF
--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -54,37 +54,37 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --concurrency=4 --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --concurrency=4 -P eventlet --queues=celery --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --concurrency=2 --queues=notify --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --concurrency=2 -P eventlet --queues=notify --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 -P eventlet --queues=backup --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --concurrency=2 --queues=translate --prefetch-multiplier=2
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --concurrency=2 -P eventlet --queues=translate --prefetch-multiplier=2
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-search]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=search --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'search@%%h' --app weblate.utils --loglevel info --concurrency=1 -P eventlet --queues=search --prefetch-multiplier=2000
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=2000
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 -P eventlet --queues=memory --prefetch-multiplier=2000
 stdout_events_enabled=true
 stderr_events_enabled=true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ zeep==3.4.0
 boto3==1.12.0
 httpretty==0.9.7
 python-dateutil==2.8.1
+eventlet==0.25.1
 # For Azure Tenant auth
 cryptography==2.8
 # Subtitles


### PR DESCRIPTION
multiprocess concurrency eats a ton of memory.  Eventlets use asynchronous IO to achieve concurrency and it is much more light weight in terms of memory usage.

Basically it reimplements https://github.com/WeblateOrg/docker/pull/133