### PR TITLE
Add libxmlsec1-openssl to runtime dependencies. This is needed by SAML auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN set -x \
     openssh-client \
     curl \
     gir1.2-pango-1.0 \
+    libxmlsec1-openssl \
     python-pip \
     python-setuptools \
     python3-gi \


### PR DESCRIPTION
this fix #546 