### PR TITLE
CI: Build images just once and share built images

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,36 +3,80 @@ name: Docker Image CI
 on: [push, pull_request]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag weblate:${{ github.sha }}
+      - name: Save Docker image
+        run: docker image save weblate:${{ github.sha }} | xz > weblate-${{ github.sha }}.tar.xz
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: docker-image
+          path: weblate-${{ github.sha }}.tar.xz
+
 
   test:
-
     runs-on: ubuntu-latest
     name: Test
-
+    needs: [build]
+    env:
+      COMPOSE_PROJECT_NAME: wl
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag weblate/weblate:latest
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: docker-image
+          path: .
+      - name: Import Docker image
+        run: xzcat weblate-${{ github.sha }}.tar.xz | docker image load
       - name: Test the Docker image
         run: |
           cd docker-compose
           ./test.sh
+
+  test-ssl:
+    runs-on: ubuntu-latest
+    name: Test SSL
+    needs: [build]
+    env:
+      COMPOSE_PROJECT_NAME: wl
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: docker-image
+          path: .
+      - name: Import Docker image
+        run: xzcat weblate-${{ github.sha }}.tar.xz | docker image load
+      - name: Prepare the container
+        run: |
+          cd docker-compose
+          docker-compose up -d
+          docker-compose down
       - name: Test the Docker image with SSL
         run: |
+          cd docker-compose
           VOLUMEPATH=$(docker volume inspect -f '{{.Mountpoint}}' wl_weblate-data)
           sudo mkdir -p $VOLUMEPATH/ssl
           sudo openssl req -x509 -nodes -days 365 -subj "/CN=weblate.example.com" -newkey rsa:2048 -keyout $VOLUMEPATH/ssl/privkey.pem -out $VOLUMEPATH/ssl/fullchain.pem
           sudo chown -R 1000:1000 $VOLUMEPATH/ssl
-          cd docker-compose
           ./test.sh 4443 https
 
   push_dockerhub:
 
     runs-on: ubuntu-latest
     name: Publish docker images
-    needs: [test]
+    needs: [test, test-ssl]
     if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master')
 
     steps:
@@ -47,9 +91,9 @@ jobs:
         run: |
           docker buildx build \
           --platform linux/amd64,linux/arm/v7,linux/arm64 \
-          --output "type=image,push=false"                \
-          --file ./Dockerfile .                           \
-          --tag weblate/weblate:LOCAL
+          --file ./Dockerfile . \
+          --load \
+          --tag weblate/weblate:latest
       - name: Log in to Docker Hub
         uses: azure/docker-login@v1
         with:
@@ -58,14 +102,12 @@ jobs:
       - name: Publish image with edge tag
         if: github.ref == 'refs/heads/master'
         run: |
-          docker tag weblate/weblate:LOCAL weblate/weblate:edge
+          docker tag weblate/weblate:latest weblate/weblate:edge
           docker push weblate/weblate:edge
       - name: Publish image with latest / version tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          docker tag weblate/weblate:LOCAL weblate/weblate:latest
+          docker tag weblate/weblate:latest weblate/weblate:latest
           docker push weblate/weblate:latest
-          docker tag weblate/weblate:LOCAL "weblate/weblate:${TAGREF#refs/tags/}"
-          docker push weblate/weblate "weblate/weblate:${TAGREF#refs/tags/}"
-        env:
-          TAGREF: ${{ github.ref }}
+          docker tag weblate/weblate:latest "weblate/weblate:${GITHUB_REF#refs/tags/}"
+          docker push weblate/weblate "weblate/weblate:${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
- build images natively and using buildx (to ensure that both approaches
  work)
- store images in the registry
- test built images
- publish them once tested

Fixes #662