### PR TITLE
Paralellize buildx jobs

### DIFF
--- a/.github/bin/bleeding
+++ b/.github/bin/bleeding
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sed \
+sed -i \
     -e 's/\(ENV VERSION .*\)/\1-dev/' \
     -e 's@Weblate==\$VERSION@https://github.com/WeblateOrg/weblate/archive/master.zip@' \
     Dockerfile

--- a/.github/bin/get-buildx-args
+++ b/.github/bin/get-buildx-args
@@ -17,7 +17,7 @@ if [ "$1" = "load" ] ; then
     echo --tag weblate/weblate:test
 else
     # List of platforms
-    echo --platform linux/amd64,linux/arm/v7,linux/arm64
+    echo --platform ${MATRIX_ARCHITECTURE:-linux/amd64,linux/arm/v7,linux/arm64}
     # Enable more platforms in future:
     # linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
 

--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Adjust bleeding edge image
+        run: .github/bin/bleeding
       - name: Configure Docker build
         run: .github/bin/get-buildx-args
       - name: Build the Docker image
@@ -50,6 +52,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Adjust bleeding edge image
+        run: .github/bin/bleeding
       - name: Configure Docker build
         run: .github/bin/get-buildx-args
       - name: Build the Docker image
@@ -77,6 +81,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Adjust bleeding edge image
+        run: .github/bin/bleeding
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -108,6 +114,8 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Adjust bleeding edge image
+        run: .github/bin/bleeding
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -155,6 +163,8 @@ jobs:
           key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
       - name: DockerHub login
         run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      - name: Adjust bleeding edge image
+        run: .github/bin/bleeding
       - name: Configure Docker build
         run: .github/bin/get-buildx-args publish-bleeding
       - name: Publish the Docker images

--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -12,6 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -21,7 +26,30 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-bleeding-${{ github.sha }}
+          key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Configure Docker build
+        run: .github/bin/get-buildx-args
+      - name: Build the Docker image
+        run: docker buildx build $(.github/bin/get-buildx-args)
+
+  buildx:
+    runs-on: ubuntu-latest
+    name: Build
+    strategy:
+      matrix:
+        architecture: [linux/arm/v7, linux/arm64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
       - name: Configure Docker build
         run: .github/bin/get-buildx-args
       - name: Build the Docker image
@@ -31,7 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     needs: [build]
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
     env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
       COMPOSE_PROJECT_NAME: wl
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +76,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-bleeding-${{ github.sha }}
+          key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -58,7 +90,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Test SSL
     needs: [build]
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
     env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
       COMPOSE_PROJECT_NAME: wl
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +107,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-bleeding-${{ github.sha }}
+          key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -98,8 +134,13 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Publish the Docker images
-    needs: [test, test-ssl]
+    needs: [test, test-ssl, buildx]
     if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master')
+    strategy:
+      matrix:
+        architecture: [linux/amd64, linux/arm/v7, linux/arm64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
 
     steps:
       - name: Checkout
@@ -111,7 +152,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-bleeding-${{ github.sha }}
+          key: ${{ runner.os }}-bleeding-${{ github.sha }}-${{ matrix.architecture }}
       - name: DockerHub login
         run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
       - name: Configure Docker build

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,6 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -15,7 +20,30 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.architecture }}
+      - name: Configure Docker build
+        run: .github/bin/get-buildx-args
+      - name: Build the Docker image
+        run: docker buildx build $(.github/bin/get-buildx-args)
+
+  buildx:
+    runs-on: ubuntu-latest
+    name: Build
+    strategy:
+      matrix:
+        architecture: [linux/arm/v7, linux/arm64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.architecture }}
       - name: Configure Docker build
         run: .github/bin/get-buildx-args
       - name: Build the Docker image
@@ -25,7 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     needs: [build]
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
     env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
       COMPOSE_PROJECT_NAME: wl
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +70,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.architecture }}
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -52,7 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Test SSL
     needs: [build]
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
     env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
       COMPOSE_PROJECT_NAME: wl
     steps:
       - uses: actions/checkout@v2
@@ -65,7 +101,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.architecture }}
       - name: Build the Docker image
         run: docker buildx build $(.github/bin/get-buildx-args load)
       - name: List Docker images
@@ -92,8 +128,13 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Publish the Docker images
-    needs: [test, test-ssl]
+    needs: [test, test-ssl, buildx]
     if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master')
+    strategy:
+      matrix:
+        architecture: [linux/amd64, linux/arm/v7, linux/arm64]
+    env:
+      MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
 
     steps:
       - name: Checkout
@@ -105,7 +146,7 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}-${{ matrix.architecture }}
       - name: DockerHub login
         run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
       - name: Configure Docker build


### PR DESCRIPTION
- build each architecture in separate job
- wait with tests only on amd64 builds

This should reduce overall time needed for CI.