### PR TITLE
Don't specify concurrency except to limit it to 1

### DIFF
--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -55,13 +55,13 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --concurrency=4 --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --concurrency=4 --queues=notify --prefetch-multiplier=10
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10
 stdout_events_enabled=true
 stderr_events_enabled=true
 
@@ -73,7 +73,7 @@ stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --concurrency=4 --queues=translate --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 


### PR DESCRIPTION
I'm trying to deploy Weblate to a small server, and running into some memory pressure because of the number of Celery workers running. I noticed that the supervisord config explicitly sets concurrency for each worker. I think it would be better to let Celery default that value to the number of cores: https://docs.celeryproject.org/en/stable/reference/celery.bin.worker.html#cmdoption-celery-worker-c

In my case, that's only 2, but on much larger machines, someone might want to be able to increase it past 4 for more throughput.

I did not change the value where concurrency=1 was specified, because presumably that is an intentional "don't scale up with the number of cores" limit.