### PR TITLE
Reduce memory footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN set -x \
     python3-setuptools \
     python3-wheel \
     python3-gdbm \
+    python3-gevent \
     gettext \
     postgresql-client \
     git \

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -55,31 +55,31 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=celery --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=notify --prefetch-multiplier=10
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=memory --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=translate --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=2
+command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=backup --prefetch-multiplier=2
 stdout_events_enabled=true
 stderr_events_enabled=true
 


### PR DESCRIPTION
celery's default concurrency mode forks.  This uses gevent instead which greatly reduces memory usage.

Before:
![Screen Shot 2020-07-21 at 6 52 46 AM](https://user-images.githubusercontent.com/466007/88052796-6c06d300-cb20-11ea-90e3-9696f9d2020a.png)

After:
![Screen Shot 2020-07-21 at 6 56 05 AM](https://user-images.githubusercontent.com/466007/88052812-70cb8700-cb20-11ea-96f6-f29f9d4bbb58.png)


Please note this is similar to #537 but uses gevent instead of eventlet, which does not have the same problems with python 3.7.

feel free to raise the concurrency level again after this change.
 