### PR TITLE
Allow user to pass arbitrary options to jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN set -x \
     python3-setuptools \
     python3-wheel \
     python3-gdbm \
+    python3-gevent \
     gettext \
     postgresql-client \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN set -x \
     python3-setuptools \
     python3-wheel \
     python3-gdbm \
-    python3-gevent \
     gettext \
     postgresql-client \
     git \

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -55,36 +55,36 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4 %(MAIN_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=notify --prefetch-multiplier=10
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10 %(NOTIFY_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=memory --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=4 %(MEMORY_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=translate --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4 %(TRANSLATE_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=backup --prefetch-multiplier=2
+command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=2 %(BACKUP_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-beat]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery beat --app weblate.utils --loglevel info --pidfile /run/celery/beat.pid
+command = /usr/local/bin/celery beat --app weblate.utils --loglevel info --pidfile /run/celery/beat.pid %(BEAT_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -55,36 +55,36 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4 %(MAIN_OPTIONS)s
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4 %(ENV_CELERY_MAIN_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10 %(NOTIFY_OPTIONS)s
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10 %(ENV_CELERY_NOTIFY_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=4 %(MEMORY_OPTIONS)s
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=4 %(ENV_CELERY_MEMORY_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4 %(TRANSLATE_OPTIONS)s
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4 %(ENV_CELERY_TRANSLATE_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=2 %(BACKUP_OPTIONS)s
+command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=2 %(ENV_CELERY_BACKUP_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-beat]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery beat --app weblate.utils --loglevel info --pidfile /run/celery/beat.pid %(BEAT_OPTIONS)s
+command = /usr/local/bin/celery beat --app weblate.utils --loglevel info --pidfile /run/celery/beat.pid %(ENV_CELERY_BEAT_OPTIONS)s
 stdout_events_enabled=true
 stderr_events_enabled=true

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -55,31 +55,31 @@ stderr_events_enabled=true
 
 [program:celery-main]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --queues=celery --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'main@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=celery --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --queues=notify --prefetch-multiplier=10
+command = /usr/local/bin/celery worker --hostname 'notify@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=notify --prefetch-multiplier=10
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=memory --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'memory@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=memory --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --queues=translate --prefetch-multiplier=4
+command = /usr/local/bin/celery worker --hostname 'translate@%%h' --app weblate.utils --loglevel info --pool=gevent --queues=translate --prefetch-multiplier=4
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1
-command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --concurrency=1 --queues=backup --prefetch-multiplier=2
+command = /usr/local/bin/celery worker --hostname 'backup@%%h' --app weblate.utils --loglevel info --pool=gevent --concurrency=1 --queues=backup --prefetch-multiplier=2
 stdout_events_enabled=true
 stderr_events_enabled=true
 

--- a/start
+++ b/start
@@ -184,6 +184,21 @@ if [ "x$1" = "xrunserver" ] ; then
     fi
     envsubst '$WEBLATE_URL_PREFIX' < $template > /etc/nginx/sites-available/default
 
+    # default values for celery options
+    : "${CELERY_MAIN_OPTIONS:=""}"
+    : "${CELERY_NOTIFY_OPTIONS:=""}"
+    : "${CELERY_TRANSLATE_OPTIONS:=""}"
+    : "${CELERY_MEMORY_OPTIONS:=""}"
+    : "${CELERY_BACKUP_OPTIONS:=""}"
+    : "${CELERY_BEAT_OPTIONS:=""}"
+
+    export CELERY_MAIN_OPTIONS
+    export CELERY_NOTIFY_OPTIONS
+    export CELERY_TRANSLATE_OPTIONS
+    export CELERY_MEMORY_OPTIONS
+    export CELERY_BACKUP_OPTIONS
+    export CELERY_BEAT_OPTIONS
+
     #  Execute supervisor
     exec supervisord --nodaemon \
         --loglevel=${SUPERVISOR_LOGLEVEL:-info} \


### PR DESCRIPTION
now the user can pass arbitrary options to jobs with environment variables.

For example:

CELERY_MAIN_OPTIONS="--pool=gevent"
CELERY_NOTIFY_OPTIONS="--pool=gevent"
CELERY_TRANSLATE_OPTIONS="--pool=gevent"
CELERY_MEMORY_OPTIONS="--pool=gevent"
CELERY_BACKUP_OPTIONS="--pool=gevent"
CELERY_BEAT_OPTIONS="--pool=gevent"

This could serve as a safer and more flexible approach than #744 