### PR TITLE
feat: allow user to specify uwsgi workers

### DIFF
--- a/etc/uwsgi/apps-enabled/weblate.ini
+++ b/etc/uwsgi/apps-enabled/weblate.ini
@@ -26,9 +26,6 @@ buffer-size   = 8192
 # Reload when consuming too much of memory
 reload-on-rss = 250
 
-# Increase number of workers for heavily loaded sites
-workers       = 8
-
 # Enable threads for Sentry error submission
 enable-threads = true
 

--- a/start
+++ b/start
@@ -191,6 +191,7 @@ if [ "x$1" = "xrunserver" ] ; then
     : "${CELERY_MEMORY_OPTIONS:=""}"
     : "${CELERY_BACKUP_OPTIONS:=""}"
     : "${CELERY_BEAT_OPTIONS:=""}"
+    : "${UWSGI_WORKERS:=$((`nproc` + 1))}"
 
     export CELERY_MAIN_OPTIONS
     export CELERY_NOTIFY_OPTIONS
@@ -198,7 +199,8 @@ if [ "x$1" = "xrunserver" ] ; then
     export CELERY_MEMORY_OPTIONS
     export CELERY_BACKUP_OPTIONS
     export CELERY_BEAT_OPTIONS
-
+    export UWSGI_WORKERS
+    
     #  Execute supervisor
     exec supervisord --nodaemon \
         --loglevel=${SUPERVISOR_LOGLEVEL:-info} \


### PR DESCRIPTION
UWSGI supports environment variables for all configuration,  as long as it is not hardcoded in weblate.ini.

This PR removes workers from weblate.ini. It will just use the default amount of workers.   A user of this image can specify the workers by adding this environment variable to the docker image:

```
UWSGI_WORKERS=8
```

Documentation is available at https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables.

For small deployments one could do:

```
UWSGI_WORKERS=1
```
or just do nothing.

Before:
![Screen Shot 2020-07-22 at 5 46 54 PM](https://user-images.githubusercontent.com/466007/88236903-b46ae180-cc43-11ea-9300-3edd609f14c9.png)
after:
![Screen Shot 2020-07-22 at 5 48 59 PM](https://user-images.githubusercontent.com/466007/88236914-b9c82c00-cc43-11ea-962c-4b1d8ac72522.png)

