### PR TITLE
nginx: Properly redirect non matching domains

### DIFF
--- a/etc/nginx/default.tpl
+++ b/etc/nginx/default.tpl
@@ -1,5 +1,7 @@
 server {
-    listen 8080 default_server;
+    listen 8080;
+    server_name ${WEBLATE_SITE_HOST};
+
     root /app/data/static;
     client_max_body_size 100M;
 
@@ -34,4 +36,9 @@ server {
         # Adjust based to uwsgi configuration:
         uwsgi_pass unix:///run/uwsgi/app/weblate/socket;
     }
+}
+
+server {
+    listen 8080 default_server;
+    return 301 http://${WEBLATE_SITE_DOMAIN}$request_uri;
 }

--- a/etc/nginx/ssl.tpl
+++ b/etc/nginx/ssl.tpl
@@ -1,5 +1,7 @@
 server {
     listen 4443 ssl;
+    server_name ${WEBLATE_SITE_HOST};
+
     ssl_certificate /app/data/ssl/fullchain.pem;
     ssl_certificate_key /app/data/ssl/privkey.pem;
 
@@ -41,5 +43,14 @@ server {
 
 server {
     listen 8080 default_server;
-    return 301 https://$host$request_uri;
+    return 301 https://${WEBLATE_SITE_DOMAIN}$request_uri;
+}
+
+server {
+    listen 4443 default_server ssl;
+
+    ssl_certificate /app/data/ssl/fullchain.pem;
+    ssl_certificate_key /app/data/ssl/privkey.pem;
+
+    return 301 https://${WEBLATE_SITE_DOMAIN}$request_uri;
 }

--- a/start
+++ b/start
@@ -184,7 +184,10 @@ if [ "x$1" = "xrunserver" ] ; then
             -out /app/data/ssl/saml.crt \
             -keyout /app/data/ssl/saml.key
     fi
-    envsubst "\$WEBLATE_URL_PREFIX" < $template > /etc/nginx/sites-available/default
+    WEBLATE_SITE_HOST="${WEBLATE_SITE_DOMAIN%:*}"
+    export WEBLATE_SITE_HOST
+    # shellcheck disable=SC2016
+    envsubst '$WEBLATE_URL_PREFIX $WEBLATE_SITE_DOMAIN $WEBLATE_SITE_HOST=' < $template > /etc/nginx/sites-available/default
 
     # default values for celery options
     : "${CELERY_MAIN_OPTIONS:=""}"


### PR DESCRIPTION
This avoids DisallowedHost warnings.

Fixes #733