### PR TITLE
Remove extra EXPOSE port in Dockerfile, resolves #863

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ RUN echo "/app/data/python" > /usr/local/lib/python3.7/dist-packages/weblate-doc
 COPY start health_check /app/bin/
 RUN chmod a+rx /app/bin/start
 
-EXPOSE 8080 4443
+EXPOSE 8080
 VOLUME /app/data
 
 # Numerical value is needed for OpenShift S2I, see


### PR DESCRIPTION
The Dockerfile contains `EXPOSE 8080 8443`. This makes this Docker image unusable to be deployed on Cloud Foundry since Cloud Foundry only allows one port to be exposed.

This PR changes this to only expose `8080`.