### PR TITLE
Revert "Add /tmp and /run volumes"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,6 @@ COPY --link --chmod=0755 start health_check /app/bin/
 EXPOSE 8080
 VOLUME /app/data
 VOLUME /app/cache
-VOLUME /tmp
-VOLUME /run
 
 # Numerical value is needed for OpenShift S2I, see
 # https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html


### PR DESCRIPTION
## Proposed changes

This reverts commit 384b4de166dd6bf208cddfa6bfaa2489922c2f4c.

These volumes are only intended to be used as tmpfs, but when adding them as VOLUME in Dockerfile, these will end up as real volumes in the swarm mode.

Fixes #2816


<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
