### PR TITLE
feat: add support for defining localtime via volume

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -270,6 +270,94 @@ jobs:
         cd docker-compose
         ./test-stop
 
+  test-localtime:
+    runs-on: ubuntu-24.04
+    name: Test localtime, stable
+    needs:
+    - build
+    - test-basic
+    env:
+      MATRIX_ARCHITECTURE: linux/amd64
+      COMPOSE_PROJECT_NAME: wl
+      PYTHONUNBUFFERED: 1
+      TEST_CONTAINER: weblate/weblate:test
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3.7.1
+      with:
+        # renovate: datasource=github-releases depName=docker/buildx
+        version: v0.18.0
+    - name: Build the Docker image
+      run: .github/bin/docker-build load
+    - name: List Docker images
+      run: docker image ls --all
+    - name: Generate configuration
+      run: |
+        cd docker-compose
+        ./test-generate 8080 http localtime
+    - name: Startup container
+      run: |
+        cd docker-compose
+        ./test-boot
+    - name: List Python packages
+      run: |
+        cd docker-compose
+        ./test-pip
+    - name: Inspect container
+      run: |
+        cd docker-compose
+        ./test-inspect
+    - name: Check service is running
+      run: |
+        cd docker-compose
+        ./test-online
+    - name: Check service health status
+      run: |
+        cd docker-compose
+        ./test-health
+    - name: Run Django Checks
+      run: |
+        cd docker-compose
+        ./test-checks
+    - name: Verify supervisor
+      run: |
+        cd docker-compose
+        ./test-supervisor
+    - name: Test admin creation
+      run: |
+        cd docker-compose
+        ./test-admin
+    - name: Test commands
+      run: |
+        cd docker-compose
+        ./test-commands
+    - name: Display logs
+      if: always()
+      run: |
+        cd docker-compose
+        ./test-logs
+    - name: Stop Weblate service
+      run: |
+        cd docker-compose
+        docker compose stop weblate
+    - name: Start Weblate service
+      run: |
+        cd docker-compose
+        docker compose start weblate
+    - name: Check service is running
+      run: |
+        cd docker-compose
+        ./test-online
+    - name: Shutdown service
+      run: |
+        cd docker-compose
+        ./test-stop
+
   test-saml:
     runs-on: ubuntu-24.04
     name: Test SAML, stable

--- a/start
+++ b/start
@@ -104,11 +104,13 @@ export PGPASSWORD="$POSTGRES_PASSWORD"
 export PGSSLMODE="$POSTGRES_SSL_MODE"
 
 # Update the time zone
-zonefile="/usr/share/zoneinfo/$WEBLATE_TIME_ZONE"
-if [ -n "$WEBLATE_TIME_ZONE" ] && [ -f "$zonefile" ] ; then
-    cat "$zonefile" > /tmp/localtime
-else
-    cat /usr/share/zoneinfo/Etc/UTC > /tmp/localtime
+if [ -w /tmp/localtime ] ; then
+    zonefile="/usr/share/zoneinfo/$WEBLATE_TIME_ZONE"
+    if [ -n "$WEBLATE_TIME_ZONE" ] && [ -f "$zonefile" ] ; then
+        cat "$zonefile" > /tmp/localtime
+    else
+        cat /usr/share/zoneinfo/Etc/UTC > /tmp/localtime
+    fi
 fi
 
 # Create fake Python app for customization


### PR DESCRIPTION
## Proposed changes

Docker engine follows symlinks when creating the volume what makes /tmp/localtime read-only. But user has apparently configured timezone in this case so we can skip this step.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
@FSeidinger-XI This should fix your issue.
