### PR TITLE
feat: automatically use X-Forwarded-For from built-in nginx

### DIFF
--- a/start
+++ b/start
@@ -260,12 +260,7 @@ if [ "$1" = "runserver" ] ; then
     mkdir -p /run/celery
     rm -f /run/celery/beat.pid
 
-    # Generate nginx configuration
-    if [ -f /app/data/ssl/privkey.pem ] ; then
-        template=/etc/nginx/ssl.tpl
-    else
-        template=/etc/nginx/default.tpl
-    fi
+    # Parse upstream X-Forwarded-For
     case "$WEBLATE_IP_PROXY_HEADER" in
         HTTP_X_FORWARDED_FOR)
             WEBLATE_REALIP="
@@ -277,6 +272,16 @@ set_real_ip_from 0.0.0.0/0;
             WEBLATE_REALIP=""
             ;;
     esac
+    # Generate nginx configuration
+    if [ -f /app/data/ssl/privkey.pem ] ; then
+        template=/etc/nginx/ssl.tpl
+        if [ -z "$WEBLATE_IP_PROXY_HEADER" ] ; then
+            # Use X-Forwarded-For from the built-in nginx
+            export WEBLATE_IP_PROXY_HEADER=HTTP_X_FORWARDED_FOR
+        fi
+    else
+        template=/etc/nginx/default.tpl
+    fi
 
     export WEBLATE_REALIP
     mkdir -p /tmp/nginx


### PR DESCRIPTION
## Proposed changes

In the SSL setup the X-Forwarded-For header is created by the built-in nginx server so Weblate should use it unless configured otherwise.

See https://github.com/WeblateOrg/weblate/issues/13325

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
