### PR TITLE
feat: build lxml/xmlsec from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN --mount=type=cache,target=/.uv-cache \
     *+* ) \
       uv pip install \
         --compile-bytecode \
+        --no-binary xmlsec \
+        --no-binary lxml \
         -r /app/src/requirements.txt \
         "https://github.com/translate/translate/archive/master.zip" \
         "https://github.com/WeblateOrg/language-data/archive/main.zip" \
@@ -27,6 +29,8 @@ RUN --mount=type=cache,target=/.uv-cache \
     * ) \
       uv pip install \
         --compile-bytecode \
+        --no-binary xmlsec \
+        --no-binary lxml \
         -r /app/src/requirements.txt \
         "Weblate[$WEBLATE_EXTRAS]==$WEBLATE_VERSION" \
       ;; \


### PR DESCRIPTION
This is needed to allow migrating to Python 3.13 as xmlsec does not ship compatible wheels there.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
