### PR TITLE
fix: disable using ports in nginx redirets

### DIFF
--- a/etc/nginx/default.tpl
+++ b/etc/nginx/default.tpl
@@ -22,6 +22,7 @@ server {
     root /app/cache/static;
     client_max_body_size {{ CLIENT_MAX_BODY_SIZE }};
     server_tokens off;
+    port_in_redirect off;
 
     {{ WEBLATE_REALIP }}
 


### PR DESCRIPTION
This breaks anubis integration because it uses server port (8080) instead of the actual port where the service is exposed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
