### PR TITLE
feat: replace gunicorn with granian

### DIFF
--- a/etc/nginx/default.tpl
+++ b/etc/nginx/default.tpl
@@ -76,7 +76,7 @@ server {
 
 {% if WEBLATE_ANUBIS_URL %}
     location ~ ^{{ WEBLATE_URL_PREFIX }}(/widget/|/exports/rss/|/healthz/|/hooks/|/accounts/complete/) {
-        proxy_pass http://unix:/run/gunicorn/app/weblate/socket;
+        proxy_pass http://unix:/run/granian/weblate.socket;
     }
 {% endif %}
 
@@ -85,7 +85,7 @@ server {
         auth_request /.within.website/x/cmd/anubis/api/check;
         error_page 401 = @redirectToAnubis;
 {% endif %}
-        proxy_pass http://unix:/run/gunicorn/app/weblate/socket;
+        proxy_pass http://unix:/run/granian/weblate.socket;
     }
 }
 

--- a/etc/supervisor/conf.d/web.conf
+++ b/etc/supervisor/conf.d/web.conf
@@ -1,22 +1,18 @@
-[program:gunicorn]
-command = /app/venv/bin/gunicorn
+[program:granian]
+command = /app/venv/bin/granian
+    --no-ws
+    --workers-max-rss 350
+    --runtime-mode mt
+    --interface wsgi
+    --workers 2
+    --backpressure %(ENV_WEB_WORKERS)s
+    --runtime-threads %(ENV_WEB_RUNTIME_THREADS)s
+    --uds /run/granian/weblate.socket
     weblate.wsgi:application
-    --preload
-    --timeout 3600
-    --graceful-timeout 3600
-    --max-requests 7000
-    --max-requests-jitter 1000
-    --workers=2
-    --threads=%(ENV_WEB_WORKERS)s
-    --access-logfile='-'
-    --error-logfile='-'
-    --forwarded-allow-ips="*"
-    --bind unix:///run/gunicorn/app/weblate/socket
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart = true
-
 
 [program:nginx]
 command = /usr/sbin/nginx -g "daemon off;"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ djangorestframework==3.16.0
 gevent==25.5.1
 git-review==2.5.0
 google-cloud-translate==3.21.1
-gunicorn==23.0.0
+granian==2.5.0
 hiredis==3.2.1
 html2text==2025.4.15
 iniparse==0.5

--- a/start
+++ b/start
@@ -253,8 +253,8 @@ if [ "$1" = "runserver" ]; then
     # Compress js and css
     run_weblate compress --force --traceback
 
-    # uswgi dir
-    mkdir -p /run/gunicorn/app/weblate
+    # wsgi socket dir
+    mkdir -p /run/granian/
 
     # Celery pid, remove possible stale PID file
     mkdir -p /run/celery
@@ -308,6 +308,7 @@ set_real_ip_from 0.0.0.0/0;
     : "${CELERY_BEAT_OPTIONS:=""}"
     : "${CELERY_SINGLE_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
     : "${WEB_WORKERS:="$WEBLATE_WORKERS"}"
+    : "${WEB_RUNTIME_THREADS:="$((WEB_WORKERS / 2))"}"
     # This is for legacy configurations, should be removed in the future
     if [ -n "$UWSGI_WORKERS" ]; then
         echo "Configuration using UWSGI_WORKERS is deprecated, please use WEB_WORKERS instead!"
@@ -322,6 +323,7 @@ set_real_ip_from 0.0.0.0/0;
     export CELERY_BEAT_OPTIONS
     export CELERY_SINGLE_OPTIONS
     export WEB_WORKERS
+    export WEB_RUNTIME_THREADS
 
     #  Execute supervisor
     exec supervisord \


### PR DESCRIPTION
- Doesn't fail requests when the worker needs to be restarted in
  multi-threaded environment (issue #3507).
- Supports limiting RSS usage reducing number of restarts.
- The WSGI core should perform way better (I don't expect visible impact
  on Weblate here, but still it heavily reduces the overhead).
    
Fixes #3507

Built on top of https://github.com/WeblateOrg/docker/pull/3509 to verify the test is effective.


<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
