### PR TITLE
fix: improve granian configuration

### DIFF
--- a/etc/supervisor/conf.d/web.conf
+++ b/etc/supervisor/conf.d/web.conf
@@ -2,12 +2,9 @@
 command = /app/venv/bin/granian
     --no-ws
     --workers-max-rss 350
-    --blocking-threads-idle-timeout 600
-    --runtime-mode mt
+    --runtime-mode st
     --interface wsgi
-    --workers 2
-    --backpressure %(ENV_WEB_WORKERS)s
-    --runtime-threads %(ENV_WEB_RUNTIME_THREADS)s
+    --workers %(ENV_WEB_WORKERS)s
     --uds /run/granian/weblate.socket
     weblate.wsgi:application
 stdout_logfile=/dev/fd/1

--- a/start
+++ b/start
@@ -307,8 +307,7 @@ set_real_ip_from 0.0.0.0/0;
     : "${CELERY_BACKUP_OPTIONS:="--concurrency 1"}"
     : "${CELERY_BEAT_OPTIONS:=""}"
     : "${CELERY_SINGLE_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
-    : "${WEB_WORKERS:="$WEBLATE_WORKERS"}"
-    : "${WEB_RUNTIME_THREADS:="$((WEB_WORKERS == 1 ? 1 : WEB_WORKERS / 2))"}"
+    : "${WEB_WORKERS:="$((WEBLATE_WORKERS <= 3 ? 2 : WEBLATE_WORKERS / 2))"}"
     # This is for legacy configurations, should be removed in the future
     if [ -n "$UWSGI_WORKERS" ]; then
         echo "Configuration using UWSGI_WORKERS is deprecated, please use WEB_WORKERS instead!"


### PR DESCRIPTION
- switch to st mode as this is mostly deployed with small amount of processes
- revert blocking-threads-idle-timeout as it does not influence what we wanted (see https://github.com/emmett-framework/granian/issues/668)
- avoid manually configuring backpressure and threads, the used value was probably wrong anyway
- dynamically scale workers to have more of them on larger setups

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
