### PR TITLE
fix: drop legacy UwSGI_WORKERS alias

### DIFF
--- a/start
+++ b/start
@@ -308,11 +308,6 @@ set_real_ip_from 0.0.0.0/0;
     : "${CELERY_BEAT_OPTIONS:=""}"
     : "${CELERY_SINGLE_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
     : "${WEB_WORKERS:="$((WEBLATE_WORKERS <= 3 ? 2 : WEBLATE_WORKERS / 2))"}"
-    # This is for legacy configurations, should be removed in the future
-    if [ -n "$UWSGI_WORKERS" ]; then
-        echo "Configuration using UWSGI_WORKERS is deprecated, please use WEB_WORKERS instead!"
-        WEB_WORKERS="$UWSGI_WORKERS"
-    fi
 
     export CELERY_MAIN_OPTIONS
     export CELERY_NOTIFY_OPTIONS


### PR DESCRIPTION
It can cause more harm now because it used to control single threaded processes and now there are 16 threads. This can easily lead to consuming database connections.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
