### PR TITLE
fix: health check error handling again

### DIFF
--- a/health_check
+++ b/health_check
@@ -12,7 +12,7 @@ if [ -f /run/supervisor.conf.d/web.conf ]; then
 fi
 
 # Supervisor based health check
-services="$(/app/venv/bin/supervisorctl status)"
+services="$(/app/venv/bin/supervisorctl status || true)"
 failing="$(echo "$services" | grep -v '^check *EXITED\|RUNNING' || true)"
 if [ -n "$failing" ]; then
     echo "$failing"


### PR DESCRIPTION
The `supervisorctl status` command may return status 3, which causes the process to terminate prematurely due to `set -e` (https://github.com/WeblateOrg/docker/commit/228558f944d41ed07103537cfa689d8c8431770c).

```
weblate@05c0208c750d:/$ services="$(/app/venv/bin/supervisorctl status)"
weblate@05c0208c750d:/$ echo $?
3
weblate@05c0208c750d:/$ echo $services
celery RUNNING pid 337, uptime 0:13:17 celery-beat RUNNING pid 338, uptime 0:13:17 check EXITED Dec 21 10:22 AM granian RUNNING pid 335, uptime 0:13:17 nginx RUNNING pid 336, uptime 0:13:17
```
```
$ sh -c 'echo start; f() { return 3; }; f; echo end;'
start
end
$ sh -c 'set -e; echo start; f() { return 3; }; f; echo end;'
start
```
Possible fix:
```
weblate@05c0208c750d:/$ services="$(/app/venv/bin/supervisorctl status || true)"
weblate@05c0208c750d:/$ echo $?
0
weblate@05c0208c750d:/$ echo $services
celery RUNNING pid 337, uptime 0:14:00 celery-beat RUNNING pid 338, uptime 0:14:00 check EXITED Dec 21 10:22 AM granian RUNNING pid 335, uptime 0:14:00 nginx RUNNING pid 336, uptime 0:14:00
```

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
