### PR TITLE
fix: validate supervisorctl exit code

### DIFF
--- a/health_check
+++ b/health_check
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 # Web health check if web is started in this container
 if [ -f /run/supervisor.conf.d/web.conf ]; then
     if [ -f /app/data/ssl/privkey.pem ]; then
@@ -13,6 +11,14 @@ fi
 
 # Supervisor based health check
 services="$(/app/venv/bin/supervisorctl status)"
+status_code=$?
+# 3 is expected as there is a single stopped service (check)
+if [ $status_code -ne 0 ] && [ $status_code -ne 3 ]; then
+    echo "supervisorctl failed ($status_code)"
+    exit 1
+fi
+
+# Look for failed services
 failing="$(echo "$services" | grep -v '^check *EXITED\|RUNNING' || true)"
 if [ -n "$failing" ]; then
     echo "$failing"


### PR DESCRIPTION
The supervisorctl status is actually exit with 3, so handle this gracefully.

Fixes #3997
Replaces #3996

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
