### PR TITLE
fix(celery): enable memory-based worker recycling

### DIFF
--- a/.github/bin/test-celery.py
+++ b/.github/bin/test-celery.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import time
+
+ATTEMPTS = 6
+RETRY_DELAY = 5
+
+
+def inspect_workers():
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "weblate",
+            "/app/venv/bin/celery",
+            "--app=weblate.utils",
+            "inspect",
+            "--timeout=10",
+            "--json",
+            "stats",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def validate_workers(stats, variant):
+    workers = {name.partition("@")[0]: values for name, values in stats.items()}
+
+    if variant == "celery-single":
+        implementation = workers["celery"]["pool"]["implementation"]
+        if "solo" not in implementation:
+            raise AssertionError(f"expected solo pool, got {implementation}")
+        return
+
+    notify_concurrency = workers["notify"]["pool"]["max-concurrency"]
+    if not 2 <= notify_concurrency <= 4:
+        raise AssertionError(
+            f"notify: expected auto-scaled concurrency from 2 to 4, "
+            f"got {notify_concurrency}"
+        )
+
+    heavy_concurrency = (notify_concurrency + 1) // 2
+    expected = {
+        "celery": (heavy_concurrency, heavy_concurrency),
+        "notify": (notify_concurrency, notify_concurrency * 4),
+        "translate": (heavy_concurrency, heavy_concurrency),
+        "memory": (1, 1),
+        "backup": (1, 1),
+    }
+
+    for name, (concurrency, prefetch_count) in expected.items():
+        worker = workers[name]
+        pool = worker["pool"]
+        implementation = pool["implementation"]
+        if "prefork" not in implementation:
+            raise AssertionError(f"{name}: expected prefork pool, got {implementation}")
+        if pool["max-concurrency"] != concurrency:
+            raise AssertionError(
+                f"{name}: expected concurrency {concurrency}, "
+                f"got {pool['max-concurrency']}"
+            )
+        if worker["prefetch_count"] != prefetch_count:
+            raise AssertionError(
+                f"{name}: expected prefetch count {prefetch_count}, "
+                f"got {worker['prefetch_count']}"
+            )
+
+
+def main():
+    variant = sys.argv[1] if len(sys.argv) > 1 else "basic"
+
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            validate_workers(inspect_workers(), variant)
+        except (
+            AssertionError,
+            KeyError,
+            json.JSONDecodeError,
+            subprocess.CalledProcessError,
+        ) as error:
+            if attempt == ATTEMPTS:
+                print(
+                    f"Celery workers did not reach the expected configuration: {error}",
+                    file=sys.stderr,
+                )
+                return 1
+            time.sleep(RETRY_DELAY)
+        else:
+            return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -96,6 +96,11 @@ jobs:
     - name: Verify supervisor
       working-directory: docker-compose
       run: ./test-supervisor
+    - name: Verify Celery workers
+      working-directory: docker-compose
+      run: python3 ../.github/bin/test-celery.py "$WEBLATE_TEST"
+      env:
+        WEBLATE_TEST: ${{ inputs.test }}
     - name: Test admin creation
       working-directory: docker-compose
       run: ./test-admin

--- a/etc/supervisor/conf.d/celery-backup.conf
+++ b/etc/supervisor/conf.d/celery-backup.conf
@@ -1,6 +1,6 @@
 [program:celery-backup]
 environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
-command = /app/venv/bin/celery worker --hostname 'backup@%%h' --loglevel info --pool=threads --concurrency=1 --queues=backup --prefetch-multiplier=2 %(ENV_CELERY_BACKUP_OPTIONS)s
+command = /app/venv/bin/celery worker --hostname 'backup@%%h' --loglevel info --pool=prefork --queues=backup --prefetch-multiplier=1 %(ENV_CELERY_BACKUP_OPTIONS)s
 autorestart = true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/etc/supervisor/conf.d/celery-celery.conf
+++ b/etc/supervisor/conf.d/celery-celery.conf
@@ -1,6 +1,6 @@
 [program:celery-celery]
 environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
-command = /app/venv/bin/celery worker --hostname 'celery@%%h' --loglevel info --queues=celery --pool=threads --prefetch-multiplier=4 %(ENV_CELERY_MAIN_OPTIONS)s
+command = /app/venv/bin/celery worker --hostname 'celery@%%h' --loglevel info --queues=celery --pool=prefork --prefetch-multiplier=1 %(ENV_CELERY_MAIN_OPTIONS)s
 autorestart = true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/etc/supervisor/conf.d/celery-memory.conf
+++ b/etc/supervisor/conf.d/celery-memory.conf
@@ -1,6 +1,6 @@
 [program:celery-memory]
 environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
-command = /app/venv/bin/celery worker --hostname 'memory@%%h' --loglevel info --queues=memory --pool=threads --prefetch-multiplier=10 %(ENV_CELERY_MEMORY_OPTIONS)s
+command = /app/venv/bin/celery worker --hostname 'memory@%%h' --loglevel info --queues=memory --pool=prefork --prefetch-multiplier=1 %(ENV_CELERY_MEMORY_OPTIONS)s
 autorestart = true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/etc/supervisor/conf.d/celery-notify.conf
+++ b/etc/supervisor/conf.d/celery-notify.conf
@@ -1,6 +1,6 @@
 [program:celery-notify]
 environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
-command = /app/venv/bin/celery worker --hostname 'notify@%%h' --loglevel info --queues=notify --pool=threads --prefetch-multiplier=20 %(ENV_CELERY_NOTIFY_OPTIONS)s
+command = /app/venv/bin/celery worker --hostname 'notify@%%h' --loglevel info --queues=notify --pool=prefork --prefetch-multiplier=4 %(ENV_CELERY_NOTIFY_OPTIONS)s
 autorestart = true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/etc/supervisor/conf.d/celery-translate.conf
+++ b/etc/supervisor/conf.d/celery-translate.conf
@@ -1,6 +1,6 @@
 [program:celery-translate]
 environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
-command = /app/venv/bin/celery worker --hostname 'translate@%%h' --loglevel info --queues=translate --pool=threads --prefetch-multiplier=4 %(ENV_CELERY_TRANSLATE_OPTIONS)s
+command = /app/venv/bin/celery worker --hostname 'translate@%%h' --loglevel info --queues=translate --pool=prefork --prefetch-multiplier=1 %(ENV_CELERY_TRANSLATE_OPTIONS)s
 autorestart = true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-# Alernative Celery pool implementation
-gevent==26.5.0
 supervisor==4.3.0

--- a/start
+++ b/start
@@ -594,6 +594,7 @@ stop_early_nginx() {
 
 calculate_worker_defaults() {
     local processors
+    local prefork_workers
 
     # Calculate number of processes, at least 2, at most 4, depending on CPU cores.
     if [[ -z $WEBLATE_WORKERS ]]; then
@@ -608,11 +609,15 @@ calculate_worker_defaults() {
         echo "Auto-scaled to $WEBLATE_WORKERS processes, adjust by setting WEBLATE_WORKERS"
     fi
 
+    # Prefork workers provide more effective parallelism than threads. Keep the
+    # notification workers at full concurrency, but limit the heavier queues.
+    prefork_workers=$(((WEBLATE_WORKERS + 1) / 2))
+
     # Default values for celery options.
-    : "${CELERY_MAIN_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
+    : "${CELERY_MAIN_OPTIONS:="--concurrency $prefork_workers"}"
     : "${CELERY_NOTIFY_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
-    : "${CELERY_TRANSLATE_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
-    : "${CELERY_MEMORY_OPTIONS:="--concurrency $((WEBLATE_WORKERS == 1 ? 1 : WEBLATE_WORKERS / 2))"}"
+    : "${CELERY_TRANSLATE_OPTIONS:="--concurrency $prefork_workers"}"
+    : "${CELERY_MEMORY_OPTIONS:="--concurrency 1"}"
     : "${CELERY_BACKUP_OPTIONS:="--concurrency 1"}"
     : "${CELERY_BEAT_OPTIONS:=}"
     : "${CELERY_SINGLE_OPTIONS:=}"


### PR DESCRIPTION
Switch workers to prefork with lower concurrency and prefetch so memory-heavy children can be recycled before triggering OOM.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
