### PR TITLE
fix(ci): retry requests during worker recycling

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -130,12 +130,18 @@ jobs:
         . docker-compose/.test.env
         set +e
         for i in $( seq 40000 ) ; do
-          if ! curl --silent --show-error --fail-with-body --insecure --output /dev/null --max-time 1 "${URL}healthz/" ; then
+          # A request assigned to a retiring worker can briefly stall; retries still detect a service which does not recover.
+          if ! curl --silent --show-error --fail-with-body --insecure --output /dev/null --max-time 1 --retry 3 --retry-all-errors --retry-delay 0 "${URL}healthz/" ; then
             echo "Failed after $i requests!"
             exit 1
           fi
         done
+    - name: Display logs
+      if: always()
+      working-directory: docker-compose
+      run: ./test-logs
     - name: Shutdown service
+      if: always()
       working-directory: docker-compose
       run: ./test-stop
 permissions:


### PR DESCRIPTION
Granian worker recycling can briefly delay an in-flight health check, making the one-second stress probe flaky. Retry transient failures while preserving logs and cleanup for failed runs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
