### PR TITLE
fix(ci): allow graceful container restart

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -116,12 +116,9 @@ jobs:
       if: always()
       working-directory: docker-compose
       run: ./test-logs
-    - name: Stop Weblate service
+    - name: Restart Weblate service
       working-directory: docker-compose
-      run: docker compose stop weblate
-    - name: Start Weblate service
-      working-directory: docker-compose
-      run: docker compose start weblate
+      run: docker compose restart --timeout 60 weblate
     - name: Check service is running
       working-directory: docker-compose
       run: ./test-online


### PR DESCRIPTION
Supervisor can take longer than Docker's default stop timeout to drain workers. Use an atomic restart with a longer timeout to avoid racing forced container teardown.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
