### PR TITLE
fix: silence early nginx access log

### DIFF
--- a/start
+++ b/start
@@ -523,9 +523,13 @@ generate_nginx_config() {
 }
 
 prepare_early_nginx_main_config() {
-    sed "s#^pid /run/nginx.pid;\$#pid $EARLY_NGINX_PID_FILE;#" /etc/nginx/nginx.conf > "$EARLY_NGINX_CONF_FILE"
+    sed \
+        -e "s#^pid /run/nginx.pid;\$#pid $EARLY_NGINX_PID_FILE;#" \
+        -e 's#^\([[:space:]]*\)access_log .*;$#\1access_log off;#' \
+        /etc/nginx/nginx.conf > "$EARLY_NGINX_CONF_FILE"
 
-    if ! grep -q "^pid $EARLY_NGINX_PID_FILE;\$" "$EARLY_NGINX_CONF_FILE"; then
+    if ! grep -q "^pid $EARLY_NGINX_PID_FILE;\$" "$EARLY_NGINX_CONF_FILE" ||
+        ! grep -q '^[[:space:]]*access_log off;$' "$EARLY_NGINX_CONF_FILE"; then
         echo "Failed to prepare early nginx configuration"
         exit 1
     fi


### PR DESCRIPTION
Busy sites can flood stdout with early nginx requests, obscuring container startup progress.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
