### PR TITLE
fix: avoid upstream errors from early nginx

### DIFF
--- a/etc/nginx/default.tpl
+++ b/etc/nginx/default.tpl
@@ -1,4 +1,7 @@
 server {
+{% if EARLY_NGINX %}
+    access_log off;
+{% endif %}
 {% if WEBLATE_BUILTIN_SSL %}
     listen 4443 ssl;
 {% if ENABLE_IPV6 %}
@@ -113,12 +116,17 @@ server {
     proxy_connect_timeout 3600;
 
 {% if WEBLATE_ANUBIS_URL %}
+{% if not EARLY_NGINX %}
     location ~ ^{{ WEBLATE_URL_PREFIX }}(/widgets?/|/idp/|/exports/rss/|/healthz/|/hooks/|/accounts/complete/|/accounts/auth/) {
         proxy_pass http://unix:{{ GRANIAN_SOCKET }}:;
     }
 {% endif %}
+{% endif %}
 
     location {{ WEBLATE_URL_PREFIX }}/ {
+{% if EARLY_NGINX %}
+        return 502;
+{% else %}
 {% if WEBLATE_ANUBIS_URL %}
         auth_request /.within.website/x/cmd/anubis/api/check;
         error_page 401 = @redirectToAnubis;
@@ -126,11 +134,15 @@ server {
         error_page 504 /__weblate_timeout__.html;
 {% endif %}
         proxy_pass http://unix:{{ GRANIAN_SOCKET }}:;
+{% endif %}
     }
 }
 
 {% if WEBLATE_BUILTIN_SSL %}
 server {
+{% if EARLY_NGINX %}
+    access_log off;
+{% endif %}
     listen 8080 default_server;
 {% if ENABLE_IPV6 %}
     listen [::]:8080 default_server;

--- a/etc/nginx/generate-site.py
+++ b/etc/nginx/generate-site.py
@@ -19,6 +19,7 @@ from django.conf import settings
     ENABLE_HTTPS,
     GRANIAN_SOCKET,
     ENABLE_IPV6,
+    EARLY_NGINX,
 ) = sys.argv[1:]
 
 
@@ -89,6 +90,7 @@ print(
             "WEBLATE_SITE_URL": WEBLATE_SITE_URL,
             "GRANIAN_SOCKET": GRANIAN_SOCKET,
             "ENABLE_IPV6": ENABLE_IPV6,
+            "EARLY_NGINX": EARLY_NGINX,
         }
     )
 )

--- a/start
+++ b/start
@@ -57,8 +57,7 @@ service_runs_migrations() {
     [[ -z $weblate_service || $weblate_service == "celery-beat" ]]
 }
 
-EARLY_NGINX_PID_FILE=/run/nginx-early.pid
-EARLY_NGINX_CONF_FILE=/tmp/nginx/nginx-early.conf
+NGINX_PID_FILE=/run/nginx.pid
 
 fail_dep() {
     >&2 echo "$1 not running!"
@@ -494,6 +493,8 @@ configure_forwarded_for() {
 }
 
 generate_nginx_config() {
+    local early_nginx=${1:-}
+
     # Make sure WEBLATE_ANUBIS_URL is set.
     : "${WEBLATE_ANUBIS_URL:=}"
     : "${WEBLATE_ENABLE_HTTPS:=}"
@@ -519,20 +520,8 @@ generate_nginx_config() {
         "$WEBLATE_ENABLE_HTTPS" \
         "$GRANIAN_SOCKET" \
         "$WEBLATE_ENABLE_IPV6" \
+        "$early_nginx" \
         > /tmp/nginx/weblate-site.conf
-}
-
-prepare_early_nginx_main_config() {
-    sed \
-        -e "s#^pid /run/nginx.pid;\$#pid $EARLY_NGINX_PID_FILE;#" \
-        -e 's#^\([[:space:]]*\)access_log .*;$#\1access_log off;#' \
-        /etc/nginx/nginx.conf > "$EARLY_NGINX_CONF_FILE"
-
-    if ! grep -q "^pid $EARLY_NGINX_PID_FILE;\$" "$EARLY_NGINX_CONF_FILE" ||
-        ! grep -q '^[[:space:]]*access_log off;$' "$EARLY_NGINX_CONF_FILE"; then
-        echo "Failed to prepare early nginx configuration"
-        exit 1
-    fi
 }
 
 start_early_nginx() {
@@ -546,16 +535,15 @@ start_early_nginx() {
 
     collect_web_static_assets
     prepare_runtime_sockets_and_pids
-    generate_nginx_config
-    prepare_early_nginx_main_config
-    rm -f "$EARLY_NGINX_PID_FILE"
+    generate_nginx_config 1
+    rm -f "$NGINX_PID_FILE"
 
     echo "Starting nginx early to serve the startup page..."
-    /usr/sbin/nginx -c "$EARLY_NGINX_CONF_FILE"
+    /usr/sbin/nginx
 
     while ((timeout < start_retries)); do
-        if [[ -s $EARLY_NGINX_PID_FILE ]]; then
-            early_nginx_pid=$(cat "$EARLY_NGINX_PID_FILE")
+        if [[ -s $NGINX_PID_FILE ]]; then
+            early_nginx_pid=$(cat "$NGINX_PID_FILE")
             if kill -0 "$early_nginx_pid" 2> /dev/null; then
                 EARLY_NGINX_STARTED=1
                 return 0
@@ -580,14 +568,14 @@ stop_early_nginx() {
         return 0
     fi
 
-    if [[ ! -s $EARLY_NGINX_PID_FILE ]]; then
+    if [[ ! -s $NGINX_PID_FILE ]]; then
         EARLY_NGINX_STARTED=0
         return 0
     fi
 
-    early_nginx_pid=$(cat "$EARLY_NGINX_PID_FILE")
+    early_nginx_pid=$(cat "$NGINX_PID_FILE")
     if ! kill -0 "$early_nginx_pid" 2> /dev/null; then
-        rm -f "$EARLY_NGINX_PID_FILE"
+        rm -f "$NGINX_PID_FILE"
         EARLY_NGINX_STARTED=0
         return 0
     fi
@@ -629,7 +617,7 @@ stop_early_nginx() {
         done
     fi
 
-    rm -f "$EARLY_NGINX_PID_FILE"
+    rm -f "$NGINX_PID_FILE"
     EARLY_NGINX_STARTED=0
 }
 

--- a/tests/integration/test-nginx-config.py
+++ b/tests/integration/test-nginx-config.py
@@ -9,7 +9,10 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def generate_config(
-    proxy_header: str = "", trusted_proxy_addresses: str = ""
+    proxy_header: str = "",
+    trusted_proxy_addresses: str = "",
+    early_nginx: bool = False,
+    anubis_url: str = "",
 ) -> subprocess.CompletedProcess[str]:
     if LOCAL_PYTHON:
         command = [
@@ -36,11 +39,12 @@ def generate_config(
             trusted_proxy_addresses,
             "100m",
             "",
-            "",
+            anubis_url,
             "test.example.com",
             "",
             "/run/granian/granian.sock",
             "",
+            "1" if early_nginx else "",
         ],
         check=False,
         capture_output=True,
@@ -49,10 +53,21 @@ def generate_config(
 
 
 class NginxConfigTest(unittest.TestCase):
+    def test_early_nginx_does_not_use_application_server(self) -> None:
+        result = generate_config(
+            early_nginx=True, anubis_url="http://anubis.example.com"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("access_log off;", result.stdout)
+        self.assertIn("return 502;", result.stdout)
+        self.assertNotIn("proxy_pass http://unix:", result.stdout)
+
     def test_forwarded_for_disabled(self) -> None:
         result = generate_config()
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("access_log off;", result.stdout)
         self.assertNotIn("real_ip_header", result.stdout)
         self.assertNotIn("set_real_ip_from", result.stdout)
 


### PR DESCRIPTION
Render an early-only site configuration that serves the existing startup response without contacting Granian. This avoids expected missing-socket noise while preserving useful nginx errors.

Disable access logging in the early server blocks and reuse the standard nginx configuration and PID, since the early process is fully stopped before supervisord starts the regular instance. Cover both rendering modes with configuration tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
