### PR TITLE
feat(celery): add configurable worker modes

### DIFF
--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -134,6 +134,28 @@ jobs:
       weblate_sha: ${{needs.revisions.outputs.weblate_sha}}
       weblate_date: ${{needs.revisions.outputs.weblate_date}}
 
+  test-single-celery-legacy:
+    needs:
+    - revisions
+    - build
+    uses: $/.github/workflows/container-test.yml
+    with:
+      variant: ${{ inputs.variant }}
+      test: celery-single-legacy
+      weblate_sha: ${{needs.revisions.outputs.weblate_sha}}
+      weblate_date: ${{needs.revisions.outputs.weblate_date}}
+
+  test-combined-celery-options:
+    needs:
+    - revisions
+    - build
+    uses: $/.github/workflows/container-test.yml
+    with:
+      variant: ${{ inputs.variant }}
+      test: celery-combined-options
+      weblate_sha: ${{needs.revisions.outputs.weblate_sha}}
+      weblate_date: ${{needs.revisions.outputs.weblate_date}}
+
   test-ssl:
     needs:
     - revisions
@@ -297,6 +319,8 @@ jobs:
     - test-saml
     - test-split
     - test-single-celery
+    - test-single-celery-legacy
+    - test-combined-celery-options
     - test-novolume
     - test-ssl
     - test-localtime

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -56,6 +56,9 @@ jobs:
       run: docker image ls --all
     - name: Test nginx configuration generation
       run: python3 tests/integration/test-nginx-config.py
+    - name: Test Celery worker mode validation
+      if: inputs.test == 'celery-single'
+      run: python3 tests/integration/test-celery-mode.py
     - name: Test content
       run: ./tests/integration/test-content
     - name: Generate configuration

--- a/etc/supervisor/conf.d/celery-combined.conf
+++ b/etc/supervisor/conf.d/celery-combined.conf
@@ -1,0 +1,8 @@
+[program:celery]
+environment = CELERY_WORKER_RUNNING=1,CELERY_APP=weblate.utils
+command = /app/venv/bin/celery worker --hostname 'celery@%%h' --loglevel info --queues=celery,notify,memory,translate,backup --pool=prefork --prefetch-multiplier=1 %(ENV_CELERY_COMBINED_OPTIONS)s
+autorestart = true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+priority = 400

--- a/start
+++ b/start
@@ -385,6 +385,51 @@ check_postgres_version() {
     fi
 }
 
+resolve_celery_worker_mode() {
+    local mode_options
+    local split_option
+    local -a split_options=()
+
+    if [[ -z ${CELERY_WORKER_MODE:-} ]]; then
+        if [[ ${CELERY_SINGLE_PROCESS:-0} == 1 ]]; then
+            CELERY_WORKER_MODE=single
+            >&2 echo "Warning: CELERY_SINGLE_PROCESS is deprecated; use CELERY_WORKER_MODE=single instead."
+        else
+            CELERY_WORKER_MODE=combined
+        fi
+    elif [[ ${CELERY_SINGLE_PROCESS:-0} == 1 ]]; then
+        >&2 echo "Warning: CELERY_SINGLE_PROCESS is deprecated and ignored because CELERY_WORKER_MODE is set; remove CELERY_SINGLE_PROCESS."
+    fi
+
+    case $CELERY_WORKER_MODE in
+    combined | split | single) ;;
+    *)
+        >&2 echo "Invalid CELERY_WORKER_MODE '$CELERY_WORKER_MODE'; expected combined, split, or single."
+        exit 1
+        ;;
+    esac
+
+    if [[ $CELERY_WORKER_MODE != split ]]; then
+        for split_option in \
+            CELERY_MAIN_OPTIONS \
+            CELERY_NOTIFY_OPTIONS \
+            CELERY_MEMORY_OPTIONS \
+            CELERY_TRANSLATE_OPTIONS \
+            CELERY_BACKUP_OPTIONS; do
+            if [[ -n ${!split_option:-} ]]; then
+                split_options+=("$split_option")
+            fi
+        done
+    fi
+
+    if ((${#split_options[@]})); then
+        mode_options="CELERY_${CELERY_WORKER_MODE^^}_OPTIONS"
+        >&2 echo "Warning: CELERY_WORKER_MODE=$CELERY_WORKER_MODE ignores split worker options: ${split_options[*]}; use $mode_options or CELERY_WORKER_MODE=split."
+    fi
+
+    export CELERY_WORKER_MODE
+}
+
 prepare_supervisor_services() {
     if service_runs_migrations; then
         DO_MIGRATE=1
@@ -406,14 +451,22 @@ prepare_supervisor_services() {
     # Symlink all non-celery services.
     find /etc/supervisor/conf.d -type f ! -name 'celery-*.conf' -exec ln -s -t "$SUPERVISOR_CONF" {} +
 
-    if ((${CELERY_SINGLE_PROCESS:-0} == 1)); then
-        # Symlink single process service only.
+    case $CELERY_WORKER_MODE in
+    combined)
+        # Symlink the combined worker and scheduler.
+        ln -s /etc/supervisor/conf.d/celery-combined.conf "$SUPERVISOR_CONF"
+        ln -s /etc/supervisor/conf.d/celery-beat.conf "$SUPERVISOR_CONF"
+        ;;
+    single)
+        # Symlink single process service and scheduler only.
         ln -s /etc/supervisor/conf.d/celery-single.conf "$SUPERVISOR_CONF"
         ln -s /etc/supervisor/conf.d/celery-beat.conf "$SUPERVISOR_CONF"
-    else
-        # Symlink all celery services but the single process.
-        find /etc/supervisor/conf.d -type f -name 'celery-*.conf' ! -name 'celery-single.conf' -exec ln -s -t "$SUPERVISOR_CONF" {} +
-    fi
+        ;;
+    split)
+        # Symlink the scheduler and all queue-specific workers.
+        find /etc/supervisor/conf.d -type f -name 'celery-*.conf' ! -name 'celery-combined.conf' ! -name 'celery-single.conf' -exec ln -s -t "$SUPERVISOR_CONF" {} +
+        ;;
+    esac
 }
 
 run_startup_maintenance() {
@@ -622,6 +675,7 @@ stop_early_nginx() {
 }
 
 calculate_worker_defaults() {
+    local combined_workers
     local processors
     local prefork_workers
 
@@ -641,8 +695,10 @@ calculate_worker_defaults() {
     # Prefork workers provide more effective parallelism than threads. Keep the
     # notification workers at full concurrency, but limit the heavier queues.
     prefork_workers=$(((WEBLATE_WORKERS + 1) / 2))
+    combined_workers=$((WEBLATE_WORKERS * 3))
 
     # Default values for celery options.
+    : "${CELERY_COMBINED_OPTIONS:="--concurrency $combined_workers"}"
     : "${CELERY_MAIN_OPTIONS:="--concurrency $prefork_workers"}"
     : "${CELERY_NOTIFY_OPTIONS:="--concurrency $WEBLATE_WORKERS"}"
     : "${CELERY_TRANSLATE_OPTIONS:="--concurrency $prefork_workers"}"
@@ -664,6 +720,7 @@ calculate_worker_defaults() {
         GRANIAN_APPLICATION=weblate.wsgi:application
     fi
 
+    export CELERY_COMBINED_OPTIONS
     export CELERY_MAIN_OPTIONS
     export CELERY_NOTIFY_OPTIONS
     export CELERY_TRANSLATE_OPTIONS
@@ -701,6 +758,9 @@ runserver_main() {
 main() {
     load_secret_env_files
     initialize_env_defaults
+    if [[ ${1:-} == "runserver" && -z ${WEBLATE_SERVICE:-} ]]; then
+        resolve_celery_worker_mode
+    fi
 
     echo "Starting Weblate $WEBLATE_VERSION..."
 

--- a/tests/integration/test-celery-mode.py
+++ b/tests/integration/test-celery-mode.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import sys
+
+
+def run_container(*environment):
+    image = os.environ.get("TEST_CONTAINER", "weblate/weblate:test")
+    command = ["docker", "run", "--rm", "--env", "WEBLATE_SITE_DOMAIN="]
+    for value in environment:
+        command.extend(("--env", value))
+    command.append(image)
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def require_output(result, expected):
+    output = result.stdout + result.stderr
+    if expected not in output:
+        print(f"Missing {expected!r} in output:\n{output}", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    invalid = run_container("CELERY_WORKER_MODE=invalid")
+    if invalid.returncode == 0:
+        print("Invalid CELERY_WORKER_MODE unexpectedly succeeded", file=sys.stderr)
+        return 1
+    if not require_output(invalid, "expected combined, split, or single"):
+        return 1
+
+    conflict = run_container(
+        "CELERY_WORKER_MODE=combined",
+        "CELERY_SINGLE_PROCESS=1",
+        "CELERY_MAIN_OPTIONS=--concurrency 2",
+    )
+    if not require_output(
+        conflict,
+        "CELERY_SINGLE_PROCESS is deprecated and ignored because "
+        "CELERY_WORKER_MODE is set",
+    ):
+        return 1
+    if not require_output(
+        conflict,
+        "CELERY_WORKER_MODE=combined ignores split worker options: "
+        "CELERY_MAIN_OPTIONS; use CELERY_COMBINED_OPTIONS",
+    ):
+        return 1
+
+    single = run_container(
+        "CELERY_WORKER_MODE=single", "CELERY_NOTIFY_OPTIONS=--concurrency 2"
+    )
+    if not require_output(
+        single,
+        "CELERY_WORKER_MODE=single ignores split worker options: "
+        "CELERY_NOTIFY_OPTIONS; use CELERY_SINGLE_OPTIONS",
+    ):
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test-celery.py
+++ b/tests/integration/test-celery.py
@@ -6,9 +6,10 @@ import time
 
 ATTEMPTS = 6
 RETRY_DELAY = 5
+QUEUES = {"backup", "celery", "memory", "notify", "translate"}
 
 
-def inspect_workers():
+def inspect_workers(command):
     result = subprocess.run(
         [
             "docker",
@@ -21,7 +22,7 @@ def inspect_workers():
             "inspect",
             "--timeout=10",
             "--json",
-            "stats",
+            command,
         ],
         check=True,
         capture_output=True,
@@ -30,14 +31,59 @@ def inspect_workers():
     return json.loads(result.stdout)
 
 
-def validate_workers(stats, variant):
-    workers = {name.partition("@")[0]: values for name, values in stats.items()}
+def validate_queues(active_queues, worker_name, expected=QUEUES):
+    queues = {queue["name"] for queue in active_queues[worker_name]}
+    if queues != expected:
+        raise AssertionError(f"expected queues {expected}, got {queues}")
 
-    if variant == "celery-single":
+
+def validate_workers(stats, active_queues, variant):
+    workers = {name.partition("@")[0]: values for name, values in stats.items()}
+    worker_queues = {
+        name.partition("@")[0]: values for name, values in active_queues.items()
+    }
+
+    if variant in {"celery-single", "celery-single-legacy"}:
+        if workers.keys() != {"celery"}:
+            raise AssertionError(f"expected one celery worker, got {workers.keys()}")
         implementation = workers["celery"]["pool"]["implementation"]
         if "solo" not in implementation:
             raise AssertionError(f"expected solo pool, got {implementation}")
+        validate_queues(worker_queues, "celery")
         return
+
+    if variant != "split":
+        if workers.keys() != {"celery"}:
+            raise AssertionError(f"expected one combined worker, got {workers.keys()}")
+        worker = workers["celery"]
+        pool = worker["pool"]
+        implementation = pool["implementation"]
+        if "prefork" not in implementation:
+            raise AssertionError(f"expected prefork pool, got {implementation}")
+        concurrency = pool["max-concurrency"]
+        if variant == "celery-combined-options":
+            if concurrency != 5:
+                raise AssertionError(
+                    f"expected overridden concurrency 5, got {concurrency}"
+                )
+        elif concurrency not in {6, 9, 12}:
+            raise AssertionError(
+                f"expected three times auto-scaled concurrency, got {concurrency}"
+            )
+        if worker["prefetch_count"] != concurrency:
+            raise AssertionError(
+                f"expected prefetch count {concurrency}, got {worker['prefetch_count']}"
+            )
+        validate_queues(worker_queues, "celery")
+        return
+
+    expected_names = {"backup", "celery", "memory", "notify", "translate"}
+    if workers.keys() != expected_names:
+        raise AssertionError(
+            f"expected split workers {expected_names}, got {workers.keys()}"
+        )
+    for name in expected_names:
+        validate_queues(worker_queues, name, {name})
 
     notify_concurrency = workers["notify"]["pool"]["max-concurrency"]
     if not 2 <= notify_concurrency <= 4:
@@ -78,7 +124,9 @@ def main():
 
     for attempt in range(1, ATTEMPTS + 1):
         try:
-            validate_workers(inspect_workers(), variant)
+            validate_workers(
+                inspect_workers("stats"), inspect_workers("active_queues"), variant
+            )
         except (
             AssertionError,
             KeyError,
@@ -93,6 +141,20 @@ def main():
                 return 1
             time.sleep(RETRY_DELAY)
         else:
+            if variant == "celery-single-legacy":
+                logs = subprocess.run(
+                    ["docker", "compose", "logs", "--no-color", "weblate"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+                warning = (
+                    "CELERY_SINGLE_PROCESS is deprecated; "
+                    "use CELERY_WORKER_MODE=single instead."
+                )
+                if warning not in logs:
+                    print("Legacy Celery mode warning was not logged", file=sys.stderr)
+                    return 1
             return 0
 
     return 1


### PR DESCRIPTION
Share Celery startup memory through a higher-concurrency combined worker while preserving split and solo modes for queue isolation and constrained deployments.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
